### PR TITLE
fix: pass query parameters in ApiClient show method to enable pagination

### DIFF
--- a/app/javascript/dashboard/api/ApiClient.js
+++ b/app/javascript/dashboard/api/ApiClient.js
@@ -43,8 +43,8 @@ class ApiClient {
     return axios.get(this.url);
   }
 
-  show(id) {
-    return axios.get(`${this.url}/${id}`);
+  show(id, params) {
+    return axios.get(`${this.url}/${id}`, { params });
   }
 
   create(data) {


### PR DESCRIPTION
The show method was not accepting or forwarding query parameters to axios, causing pagination parameters (page, per_page) to be ignored on detail endpoints.

# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
