### PR TITLE
fix: replace 'bot' with 'Agente de IA' in FAQ translations

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -503,7 +503,7 @@
           },
           "TELEGRAM": {
             "TITLE": "Telegram",
-            "DESCRIPTION": "Configure Telegram channel using Bot token"
+            "DESCRIPTION": "Configure Telegram channel using AI agent token"
           },
           "LINE": {
             "TITLE": "Line",

--- a/app/javascript/dashboard/i18n/locale/en/knowledgeBase.json
+++ b/app/javascript/dashboard/i18n/locale/en/knowledgeBase.json
@@ -274,7 +274,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs yet",
-        "SUBTITLE": "Create categories and add FAQ items to help your bot answer common questions."
+        "SUBTITLE": "Create categories and add FAQ items to help your AI agent answer common questions."
       },
       "VISIBILITY": {
         "HIDDEN": "FAQ hidden successfully",

--- a/app/javascript/dashboard/i18n/locale/es/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/es/inboxMgmt.json
@@ -458,7 +458,7 @@
         "TITLE": "Canal de Telegram",
         "DESC": "Integre con el canal de Telegram y comience a apoyar a sus clientes.",
         "BOT_TOKEN": {
-          "LABEL": "Bot Token",
+          "LABEL": "Token de Agente de IA",
           "SUBTITLE": "Configura el token de agente IA que has obtenido de Telegram BotFather.",
           "PLACEHOLDER": "Agente IA Token"
         },
@@ -499,7 +499,7 @@
           },
           "TELEGRAM": {
             "TITLE": "Telegram",
-            "DESCRIPTION": "Configure Telegram channel using Bot token"
+            "DESCRIPTION": "Configura el canal de Telegram usando el token de Agente de IA"
           },
           "LINE": {
             "TITLE": "Line",

--- a/app/javascript/dashboard/i18n/locale/es/knowledgeBase.json
+++ b/app/javascript/dashboard/i18n/locale/es/knowledgeBase.json
@@ -274,7 +274,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "Aún no hay FAQs",
-        "SUBTITLE": "Crea categorías y agrega preguntas frecuentes para ayudar a tu bot a responder preguntas comunes."
+        "SUBTITLE": "Crea categorías y agrega preguntas frecuentes para ayudar a tu Agente de IA a responder preguntas comunes."
       },
       "VISIBILITY": {
         "HIDDEN": "FAQ ocultada exitosamente",


### PR DESCRIPTION
- EN: "Bot token" → "AI agent token" in Telegram description
- EN: "your bot" → "your AI agent" in FAQ empty state
- ES: "Bot Token" → "Token de Agente de IA" in label
- ES: Telegram description translated to Spanish
- ES: "tu bot" → "tu Agente de IA" in FAQ empty state
