### PR TITLE
fix: import contact tag translate

### DIFF
--- a/app/javascript/dashboard/i18n/locale/es/advancedFilters.json
+++ b/app/javascript/dashboard/i18n/locale/es/advancedFilters.json
@@ -49,6 +49,7 @@
       "ASSIGNEE_NAME": "Nombre Asignado",
       "INBOX_NAME": "Nombre de la bandeja de entrada",
       "TEAM_NAME": "Nombre del equipo",
+      "CONTACT_NAME": "Contact name",
       "CONVERSATION_IDENTIFIER": "Identificador de conversacion",
       "CAMPAIGN_NAME": "Nombre de Campaña",
       "LABELS": "Etiquetas",


### PR DESCRIPTION
- add missing translation for 'CONTACT_NAME' in advancedFilters.json