### PR TITLE
feat: supervisor role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ BASE-DE-DATOS.md
 !.husky/.gitkeep
 *.md
 !docs/**/*.md
+/docs

--- a/app/controllers/api/v1/accounts/appointments_controller.rb
+++ b/app/controllers/api/v1/accounts/appointments_controller.rb
@@ -18,8 +18,8 @@ class Api::V1::Accounts::AppointmentsController < Api::V1::Accounts::BaseControl
 
   def index
     appointments = Current.account.appointments.includes(:contact)
-    # Supervisor solo ve citas de contactos con conversaciones asignadas a sí mismo o subordinados
-    appointments = filter_appointments_for_supervisor(appointments) if current_account_user&.supervisor?
+    # Supervisor only sees appointments of contacts with conversations assigned to themselves or subordinates
+    appointments = filter_appointments_for_supervisor(appointments) if Current.account_user&.supervisor?
     @appointments = fetch_appointments(appointments)
     @appointments_count = @appointments.total_count
   end
@@ -32,8 +32,8 @@ class Api::V1::Accounts::AppointmentsController < Api::V1::Accounts::BaseControl
        OR appointments.location ILIKE :search OR appointments.description ILIKE :search',
       search: "%#{params[:q].strip}%"
     )
-    # Supervisor solo ve citas de contactos con conversaciones asignadas a sí mismo o subordinados
-    appointments = filter_appointments_for_supervisor(appointments) if current_account_user&.supervisor?
+    # Supervisor only sees appointments of contacts with conversations assigned to themselves or subordinates
+    appointments = filter_appointments_for_supervisor(appointments) if Current.account_user&.supervisor?
     @appointments = fetch_appointments(appointments)
     @appointments_count = @appointments.total_count
   end
@@ -113,12 +113,8 @@ class Api::V1::Accounts::AppointmentsController < Api::V1::Accounts::BaseControl
       .per(RESULTS_PER_PAGE)
   end
 
-  def current_account_user
-    @current_account_user ||= Current.account.account_users.find_by(user_id: Current.user.id)
-  end
-
   def filter_appointments_for_supervisor(appointments)
-    assignee_ids = current_account_user.all_subordinate_user_ids + [Current.user.id]
+    assignee_ids = Current.account_user.all_subordinate_user_ids + [Current.user.id]
     contact_ids = Current.account.conversations
                          .where(assignee_id: assignee_ids)
                          .pluck(:contact_id)

--- a/app/controllers/api/v1/accounts/appointments_controller.rb
+++ b/app/controllers/api/v1/accounts/appointments_controller.rb
@@ -18,6 +18,8 @@ class Api::V1::Accounts::AppointmentsController < Api::V1::Accounts::BaseControl
 
   def index
     appointments = Current.account.appointments.includes(:contact)
+    # Supervisor solo ve citas de contactos con conversaciones asignadas a sí mismo o subordinados
+    appointments = filter_appointments_for_supervisor(appointments) if current_account_user&.supervisor?
     @appointments = fetch_appointments(appointments)
     @appointments_count = @appointments.total_count
   end
@@ -30,6 +32,8 @@ class Api::V1::Accounts::AppointmentsController < Api::V1::Accounts::BaseControl
        OR appointments.location ILIKE :search OR appointments.description ILIKE :search',
       search: "%#{params[:q].strip}%"
     )
+    # Supervisor solo ve citas de contactos con conversaciones asignadas a sí mismo o subordinados
+    appointments = filter_appointments_for_supervisor(appointments) if current_account_user&.supervisor?
     @appointments = fetch_appointments(appointments)
     @appointments_count = @appointments.total_count
   end
@@ -107,5 +111,18 @@ class Api::V1::Accounts::AppointmentsController < Api::V1::Accounts::BaseControl
       .includes(:contact)
       .page(@current_page)
       .per(RESULTS_PER_PAGE)
+  end
+
+  def current_account_user
+    @current_account_user ||= Current.account.account_users.find_by(user_id: Current.user.id)
+  end
+
+  def filter_appointments_for_supervisor(appointments)
+    assignee_ids = current_account_user.all_subordinate_user_ids + [Current.user.id]
+    contact_ids = Current.account.conversations
+                         .where(assignee_id: assignee_ids)
+                         .pluck(:contact_id)
+                         .uniq
+    appointments.where(contact_id: contact_ids)
   end
 end

--- a/app/controllers/api/v1/accounts/assignable_agents_controller.rb
+++ b/app/controllers/api/v1/accounts/assignable_agents_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::Accounts::AssignableAgentsController < Api::V1::Accounts::BaseCon
     end
     agent_ids = agent_ids.inject(:&)
     agents = Current.account.users.where(id: agent_ids)
-    @assignable_agents = (agents + Current.account.administrators).uniq
+    @assignable_agents = (agents + Current.account.administrators + supervisors_for_inboxes(agent_ids)).uniq
   end
 
   private
@@ -20,5 +20,12 @@ class Api::V1::Accounts::AssignableAgentsController < Api::V1::Accounts::BaseCon
 
   def permitted_params
     params.permit(inbox_ids: [])
+  end
+
+  # Only include supervisors whose subordinates are members of the inbox
+  def supervisors_for_inboxes(member_ids)
+    Current.account.account_users.supervisor.includes(:user).select do |account_user|
+      (account_user.subordinate_user_ids & member_ids).any?
+    end.map(&:user)
   end
 end

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -55,6 +55,8 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   def active
     contacts = Current.account.contacts.where(id: ::OnlineStatusTracker
                   .get_available_contact_ids(Current.account.id))
+    # Supervisor solo ve contactos con conversaciones asignadas a sí mismo o subordinados
+    contacts = filter_contacts_for_supervisor(contacts) if current_account_user&.supervisor?
     @contacts = fetch_contacts(contacts)
     @contacts_count = @contacts.total_count
   end
@@ -124,8 +126,24 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
 
     @resolved_contacts = Current.account.contacts.resolved_contacts(use_crm_v2: Current.account.feature_enabled?('crm_v2'))
 
+    # Supervisor solo ve contactos con conversaciones asignadas a sí mismo o subordinados
+    @resolved_contacts = filter_contacts_for_supervisor(@resolved_contacts) if current_account_user&.supervisor?
+
     @resolved_contacts = @resolved_contacts.tagged_with(params[:labels], any: true) if params[:labels].present?
     @resolved_contacts
+  end
+
+  def current_account_user
+    @current_account_user ||= Current.account.account_users.find_by(user_id: Current.user.id)
+  end
+
+  def filter_contacts_for_supervisor(contacts)
+    assignee_ids = current_account_user.all_subordinate_user_ids + [Current.user.id]
+    contact_ids = Current.account.conversations
+                         .where(assignee_id: assignee_ids)
+                         .pluck(:contact_id)
+                         .uniq
+    contacts.where(id: contact_ids)
   end
 
   def set_current_page

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -55,8 +55,8 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   def active
     contacts = Current.account.contacts.where(id: ::OnlineStatusTracker
                   .get_available_contact_ids(Current.account.id))
-    # Supervisor solo ve contactos con conversaciones asignadas a sí mismo o subordinados
-    contacts = filter_contacts_for_supervisor(contacts) if current_account_user&.supervisor?
+    # Supervisor only sees contacts with conversations assigned to themselves or subordinates
+    contacts = filter_contacts_for_supervisor(contacts) if Current.account_user&.supervisor?
     @contacts = fetch_contacts(contacts)
     @contacts_count = @contacts.total_count
   end
@@ -126,19 +126,15 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
 
     @resolved_contacts = Current.account.contacts.resolved_contacts(use_crm_v2: Current.account.feature_enabled?('crm_v2'))
 
-    # Supervisor solo ve contactos con conversaciones asignadas a sí mismo o subordinados
-    @resolved_contacts = filter_contacts_for_supervisor(@resolved_contacts) if current_account_user&.supervisor?
+    # Supervisor only sees contacts with conversations assigned to themselves or subordinates
+    @resolved_contacts = filter_contacts_for_supervisor(@resolved_contacts) if Current.account_user&.supervisor?
 
     @resolved_contacts = @resolved_contacts.tagged_with(params[:labels], any: true) if params[:labels].present?
     @resolved_contacts
   end
 
-  def current_account_user
-    @current_account_user ||= Current.account.account_users.find_by(user_id: Current.user.id)
-  end
-
   def filter_contacts_for_supervisor(contacts)
-    assignee_ids = current_account_user.all_subordinate_user_ids + [Current.user.id]
+    assignee_ids = Current.account_user.all_subordinate_user_ids + [Current.user.id]
     contact_ids = Current.account.conversations
                          .where(assignee_id: assignee_ids)
                          .pluck(:contact_id)

--- a/app/javascript/dashboard/composables/commands/useGoToCommandHotKeys.js
+++ b/app/javascript/dashboard/composables/commands/useGoToCommandHotKeys.js
@@ -30,7 +30,7 @@ const GO_TO_COMMANDS = [
     section: 'COMMAND_BAR.SECTIONS.GENERAL',
     icon: ICON_CONVERSATION_DASHBOARD,
     path: accountId => `accounts/${accountId}/dashboard`,
-    role: ['administrator', 'agent'],
+    role: ['administrator', 'supervisor', 'agent'],
   },
   {
     id: 'goto_contacts_dashboard',
@@ -39,7 +39,7 @@ const GO_TO_COMMANDS = [
     featureFlag: FEATURE_FLAGS.CRM,
     icon: ICON_CONTACT_DASHBOARD,
     path: accountId => `accounts/${accountId}/contacts`,
-    role: ['administrator', 'agent'],
+    role: ['administrator', 'supervisor', 'agent'],
   },
   {
     id: 'open_reports_overview',
@@ -138,7 +138,7 @@ const GO_TO_COMMANDS = [
     section: 'COMMAND_BAR.SECTIONS.SETTINGS',
     icon: ICON_CANNED_RESPONSE,
     path: accountId => `accounts/${accountId}/settings/canned-response/list`,
-    role: ['administrator', 'agent'],
+    role: ['administrator', 'supervisor', 'agent'],
   },
   {
     id: 'open_applications_settings',
@@ -163,7 +163,7 @@ const GO_TO_COMMANDS = [
     section: 'COMMAND_BAR.SECTIONS.SETTINGS',
     icon: ICON_USER_PROFILE,
     path: accountId => `accounts/${accountId}/profile/settings`,
-    role: ['administrator', 'agent'],
+    role: ['administrator', 'supervisor', 'agent'],
   },
   {
     id: 'open_notifications',
@@ -171,7 +171,7 @@ const GO_TO_COMMANDS = [
     section: 'COMMAND_BAR.SECTIONS.SETTINGS',
     icon: ICON_NOTIFICATION,
     path: accountId => `accounts/${accountId}/notifications`,
-    role: ['administrator', 'agent'],
+    role: ['administrator', 'supervisor', 'agent'],
   },
 ];
 

--- a/app/javascript/dashboard/constants/permissions.js
+++ b/app/javascript/dashboard/constants/permissions.js
@@ -7,7 +7,7 @@ export const AVAILABLE_CUSTOM_ROLE_PERMISSIONS = [
   'knowledge_base_manage',
 ];
 
-export const ROLES = ['agent', 'administrator'];
+export const ROLES = ['agent', 'administrator', 'supervisor'];
 
 export const CONVERSATION_PERMISSIONS = [
   'conversation_manage',

--- a/app/javascript/dashboard/i18n/locale/en/agentMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/agentMgmt.json
@@ -7,6 +7,7 @@
     "LEARN_MORE": "Learn about user roles",
     "AGENT_TYPES": {
       "ADMINISTRATOR": "Administrator",
+      "SUPERVISOR": "Supervisor",
       "AGENT": "Agent"
     },
     "LIST": {

--- a/app/javascript/dashboard/routes/dashboard/captain/captain.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/captain/captain.routes.js
@@ -18,13 +18,13 @@ import ResponsesPendingIndex from './responses/Pending.vue';
 import CustomToolsIndex from './tools/Index.vue';
 
 const meta = {
-  permissions: ['administrator', 'agent'],
+  permissions: ['administrator', 'supervisor', 'agent'],
   featureFlag: FEATURE_FLAGS.CAPTAIN,
   installationTypes: [INSTALLATION_TYPES.CLOUD, INSTALLATION_TYPES.ENTERPRISE],
 };
 
 const metaV2 = {
-  permissions: ['administrator', 'agent'],
+  permissions: ['administrator', 'supervisor', 'agent'],
   featureFlag: FEATURE_FLAGS.CAPTAIN_V2,
   installationTypes: [INSTALLATION_TYPES.CLOUD, INSTALLATION_TYPES.ENTERPRISE],
 };
@@ -100,7 +100,7 @@ const assistantRoutes = [
     component: AssistantEmptyStateIndex,
     name: 'captain_assistants_create_index',
     meta: {
-      permissions: ['administrator', 'agent'],
+      permissions: ['administrator', 'supervisor', 'agent'],
       installationTypes: [
         INSTALLATION_TYPES.CLOUD,
         INSTALLATION_TYPES.ENTERPRISE,

--- a/app/javascript/dashboard/routes/dashboard/companies/routes.js
+++ b/app/javascript/dashboard/routes/dashboard/companies/routes.js
@@ -5,7 +5,7 @@ import { INSTALLATION_TYPES } from 'dashboard/constants/installationTypes';
 
 const commonMeta = {
   featureFlag: FEATURE_FLAGS.COMPANIES,
-  permissions: ['administrator', 'agent'],
+  permissions: ['administrator', 'supervisor', 'agent'],
   installationTypes: [INSTALLATION_TYPES.CLOUD, INSTALLATION_TYPES.ENTERPRISE],
 };
 

--- a/app/javascript/dashboard/routes/dashboard/contacts/routes.js
+++ b/app/javascript/dashboard/routes/dashboard/contacts/routes.js
@@ -6,7 +6,7 @@ import { FEATURE_FLAGS } from '../../../featureFlags';
 
 const commonMeta = {
   featureFlag: FEATURE_FLAGS.CRM,
-  permissions: ['administrator', 'agent', 'contact_manage'],
+  permissions: ['administrator', 'supervisor', 'agent', 'contact_manage'],
 };
 
 export const routes = [

--- a/app/javascript/dashboard/routes/dashboard/conversation/conversation.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/conversation/conversation.routes.js
@@ -5,6 +5,7 @@ import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 
 const CONVERSATION_PERMISSIONS = [
   'administrator',
+  'supervisor',
   'agent',
   'conversation_manage',
   'conversation_unassigned_manage',

--- a/app/javascript/dashboard/routes/dashboard/customers/routes.js
+++ b/app/javascript/dashboard/routes/dashboard/customers/routes.js
@@ -2,7 +2,7 @@ import { frontendURL } from '../../../helper/URLHelper';
 import CustomerManageView from './pages/CustomerManageView.vue';
 
 const commonMeta = {
-  permissions: ['administrator', 'agent', 'contact_manage'],
+  permissions: ['administrator', 'supervisor', 'agent', 'contact_manage'],
 };
 
 export const routes = [

--- a/app/javascript/dashboard/routes/dashboard/dashboard.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/dashboard.routes.js
@@ -39,7 +39,7 @@ export default {
       path: frontendURL('accounts/:accountId/suspended'),
       name: 'account_suspended',
       meta: {
-        permissions: ['administrator', 'agent', 'custom_role'],
+        permissions: ['administrator', 'supervisor', 'agent', 'custom_role'],
       },
       component: Suspended,
     },

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/helpcenter.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/helpcenter.routes.js
@@ -96,7 +96,8 @@ const portalRoutes = [
     name: 'portals_index',
     meta: {
       featureFlag: FEATURE_FLAGS.HELP_CENTER,
-      permissions: ['administrator', 'knowledge_base_manage'],
+      // TODO: Add 'supervisor', 'knowledge_base_manage' when needed
+      permissions: ['administrator'],
     },
     component: PortalsIndex,
   },

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/helpcenter.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/helpcenter.routes.js
@@ -24,7 +24,7 @@ const PortalsSettingsIndexPage = () =>
 
 const meta = {
   featureFlag: FEATURE_FLAGS.HELP_CENTER,
-  permissions: ['administrator', 'agent', 'knowledge_base_manage'],
+  permissions: ['administrator', 'supervisor', 'agent', 'knowledge_base_manage'],
 };
 const portalRoutes = [
   {

--- a/app/javascript/dashboard/routes/dashboard/notifications/routes.js
+++ b/app/javascript/dashboard/routes/dashboard/notifications/routes.js
@@ -18,7 +18,7 @@ export const routes = [
         name: 'notifications_index',
         component: NotificationsView,
         meta: {
-          permissions: ['administrator', 'agent', 'custom_role'],
+          permissions: ['administrator', 'supervisor', 'agent', 'custom_role'],
         },
       },
     ],

--- a/app/javascript/dashboard/routes/dashboard/settings/agents/AddAgent.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/agents/AddAgent.vue
@@ -97,6 +97,11 @@ const roles = computed(() => {
       label: t('AGENT_MGMT.AGENT_TYPES.ADMINISTRATOR'),
     },
     {
+      id: 'supervisor',
+      name: 'supervisor',
+      label: t('AGENT_MGMT.AGENT_TYPES.SUPERVISOR'),
+    },
+    {
       id: 'agent',
       name: 'agent',
       label: t('AGENT_MGMT.AGENT_TYPES.AGENT'),

--- a/app/javascript/dashboard/routes/dashboard/settings/agents/EditAgent.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/agents/EditAgent.vue
@@ -157,6 +157,11 @@ const roles = computed(() => {
       label: t('AGENT_MGMT.AGENT_TYPES.ADMINISTRATOR'),
     },
     {
+      id: 'supervisor',
+      name: 'supervisor',
+      label: t('AGENT_MGMT.AGENT_TYPES.SUPERVISOR'),
+    },
+    {
       id: 'agent',
       name: 'agent',
       label: t('AGENT_MGMT.AGENT_TYPES.AGENT'),

--- a/app/javascript/dashboard/routes/dashboard/settings/profile/profile.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/profile/profile.routes.js
@@ -11,7 +11,7 @@ export default {
       path: frontendURL('accounts/:accountId/profile'),
       name: 'profile_settings',
       meta: {
-        permissions: ['administrator', 'agent', 'custom_role'],
+        permissions: ['administrator', 'supervisor', 'agent', 'custom_role'],
       },
       component: SettingsContent,
       children: [
@@ -20,7 +20,7 @@ export default {
           name: 'profile_settings_index',
           component: Index,
           meta: {
-            permissions: ['administrator', 'agent', 'custom_role'],
+            permissions: ['administrator', 'supervisor', 'agent', 'custom_role'],
           },
         },
         {
@@ -28,7 +28,7 @@ export default {
           name: 'profile_settings_mfa',
           component: MfaSettings,
           meta: {
-            permissions: ['administrator', 'agent', 'custom_role'],
+            permissions: ['administrator', 'supervisor', 'agent', 'custom_role'],
           },
           beforeEnter: (to, from, next) => {
             // Check if MFA is enabled globally

--- a/app/javascript/dashboard/store/modules/conversations/helpers.js
+++ b/app/javascript/dashboard/store/modules/conversations/helpers.js
@@ -81,7 +81,7 @@ export const applyRoleFilter = (
   // the backend handles this by checking the custom_role_id at the user model
   // here however, the `getUserRole` returns "custom_role" if the id is present,
   // so we can check the role === "agent" directly
-  if (['administrator', 'agent'].includes(role)) {
+  if (['administrator', 'supervisor', 'agent'].includes(role)) {
     return true;
   }
 

--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -33,7 +33,7 @@ class ActionCableListener < BaseListener
   def message_created(event)
     message, account = extract_message_and_account(event)
     conversation = message.conversation
-    tokens = user_tokens(account, conversation.inbox.members) + contact_tokens(conversation.contact_inbox, message)
+    tokens = user_tokens(account, conversation.inbox.members, conversation) + contact_tokens(conversation.contact_inbox, message)
 
     broadcast(account, tokens, MESSAGE_CREATED, message.push_event_data)
   end
@@ -41,7 +41,7 @@ class ActionCableListener < BaseListener
   def message_updated(event)
     message, account = extract_message_and_account(event)
     conversation = message.conversation
-    tokens = user_tokens(account, conversation.inbox.members) + contact_tokens(conversation.contact_inbox, message)
+    tokens = user_tokens(account, conversation.inbox.members, conversation) + contact_tokens(conversation.contact_inbox, message)
 
     broadcast(account, tokens, MESSAGE_UPDATED, message.push_event_data.merge(previous_changes: event.data[:previous_changes]))
   end
@@ -49,35 +49,35 @@ class ActionCableListener < BaseListener
   def first_reply_created(event)
     message, account = extract_message_and_account(event)
     conversation = message.conversation
-    tokens = user_tokens(account, conversation.inbox.members)
+    tokens = user_tokens(account, conversation.inbox.members, conversation)
 
     broadcast(account, tokens, FIRST_REPLY_CREATED, message.push_event_data)
   end
 
   def conversation_created(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = user_tokens(account, conversation.inbox.members) + contact_inbox_tokens(conversation.contact_inbox)
+    tokens = user_tokens(account, conversation.inbox.members, conversation) + contact_inbox_tokens(conversation.contact_inbox)
 
     broadcast(account, tokens, CONVERSATION_CREATED, conversation.push_event_data)
   end
 
   def conversation_read(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = user_tokens(account, conversation.inbox.members)
+    tokens = user_tokens(account, conversation.inbox.members, conversation)
 
     broadcast(account, tokens, CONVERSATION_READ, conversation.push_event_data)
   end
 
   def conversation_status_changed(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = user_tokens(account, conversation.inbox.members) + contact_inbox_tokens(conversation.contact_inbox)
+    tokens = user_tokens(account, conversation.inbox.members, conversation) + contact_inbox_tokens(conversation.contact_inbox)
 
     broadcast(account, tokens, CONVERSATION_STATUS_CHANGED, conversation.push_event_data)
   end
 
   def conversation_updated(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = user_tokens(account, conversation.inbox.members) + contact_inbox_tokens(conversation.contact_inbox)
+    tokens = user_tokens(account, conversation.inbox.members, conversation) + contact_inbox_tokens(conversation.contact_inbox)
 
     broadcast(account, tokens, CONVERSATION_UPDATED, conversation.push_event_data)
   end
@@ -116,21 +116,21 @@ class ActionCableListener < BaseListener
 
   def assignee_changed(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = user_tokens(account, conversation.inbox.members)
+    tokens = user_tokens(account, conversation.inbox.members, conversation)
 
     broadcast(account, tokens, ASSIGNEE_CHANGED, conversation.push_event_data)
   end
 
   def team_changed(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = user_tokens(account, conversation.inbox.members)
+    tokens = user_tokens(account, conversation.inbox.members, conversation)
 
     broadcast(account, tokens, TEAM_CHANGED, conversation.push_event_data)
   end
 
   def conversation_contact_changed(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = user_tokens(account, conversation.inbox.members)
+    tokens = user_tokens(account, conversation.inbox.members, conversation)
 
     broadcast(account, tokens, CONVERSATION_CONTACT_CHANGED, conversation.push_event_data)
   end
@@ -170,13 +170,25 @@ class ActionCableListener < BaseListener
 
   def typing_event_listener_tokens(account, conversation, user)
     current_user_token = user.is_a?(Contact) ? conversation.contact_inbox.pubsub_token : user.pubsub_token
-    (user_tokens(account, conversation.inbox.members) + [conversation.contact_inbox.pubsub_token]) - [current_user_token]
+    (user_tokens(account, conversation.inbox.members, conversation) + [conversation.contact_inbox.pubsub_token]) - [current_user_token]
   end
 
-  def user_tokens(account, agents)
+  def user_tokens(account, agents, conversation = nil)
     agent_tokens = agents.pluck(:pubsub_token)
     admin_tokens = account.administrators.pluck(:pubsub_token)
-    (agent_tokens + admin_tokens).uniq
+    supervisor_tokens = supervisor_tokens_for_conversation(account, conversation)
+    (agent_tokens + admin_tokens + supervisor_tokens).uniq
+  end
+
+  # Only notify supervisors if the conversation is assigned to themselves or one of their subordinates
+  def supervisor_tokens_for_conversation(account, conversation)
+    return [] if conversation.nil? || conversation.assignee_id.nil?
+
+    account.account_users.supervisor.includes(:user).select do |account_user|
+      # Supervisor receives if assigned to them OR to their subordinates
+      conversation.assignee_id == account_user.user_id ||
+        account_user.all_subordinate_user_ids.include?(conversation.assignee_id)
+    end.map { |au| au.user.pubsub_token }
   end
 
   def contact_tokens(contact_inbox, message)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -130,6 +130,10 @@ class Account < ApplicationRecord
     users.where(account_users: { role: :administrator })
   end
 
+  def supervisors
+    users.where(account_users: { role: :supervisor })
+  end
+
   def all_conversation_tags
     # returns array of tags
     conversation_ids = conversations.pluck(:id)

--- a/app/models/account_user.rb
+++ b/app/models/account_user.rb
@@ -71,10 +71,13 @@ class AccountUser < ApplicationRecord
     subordinates.pluck(:user_id)
   end
 
-  def all_subordinate_user_ids
+  def all_subordinate_user_ids(visited = Set.new)
+    return [] if visited.include?(id)
+
+    visited.add(id)
     ids = subordinate_user_ids
-    subordinates.each do |sub|
-      ids += sub.all_subordinate_user_ids if sub.supervisor?
+    subordinates.includes(:subordinates).each do |sub|
+      ids += sub.all_subordinate_user_ids(visited) if sub.supervisor?
     end
     ids.uniq
   end

--- a/app/models/account_user.rb
+++ b/app/models/account_user.rb
@@ -36,7 +36,7 @@ class AccountUser < ApplicationRecord
 
   has_many :subordinates, class_name: 'AccountUser', foreign_key: 'responsible_id', dependent: :nullify, inverse_of: :responsible
 
-  enum role: { agent: 0, administrator: 1 }
+  enum role: { agent: 0, administrator: 1, supervisor: 2 }
   enum availability: { online: 0, offline: 1, busy: 2 }
 
   accepts_nested_attributes_for :account
@@ -61,7 +61,22 @@ class AccountUser < ApplicationRecord
   end
 
   def permissions
-    administrator? ? ['administrator'] : ['agent']
+    return ['administrator'] if administrator?
+    return ['supervisor'] if supervisor?
+
+    ['agent']
+  end
+
+  def subordinate_user_ids
+    subordinates.pluck(:user_id)
+  end
+
+  def all_subordinate_user_ids
+    ids = subordinate_user_ids
+    subordinates.each do |sub|
+      ids += sub.all_subordinate_user_ids if sub.supervisor?
+    end
+    ids.uniq
   end
 
   def push_event_data

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -162,7 +162,17 @@ class Inbox < ApplicationRecord
   end
 
   def assignable_agents
-    (account.users.where(id: members.select(:user_id)) + account.administrators).uniq
+    member_ids = members.pluck(:user_id)
+    inbox_members = account.users.where(id: member_ids)
+    supervisors = supervisors_for_inbox(member_ids)
+    (inbox_members + account.administrators + supervisors).uniq
+  end
+
+  # Only include supervisors whose subordinates are members of this inbox
+  def supervisors_for_inbox(member_ids)
+    account.account_users.supervisor.includes(:user).select do |account_user|
+      (account_user.subordinate_user_ids & member_ids).any?
+    end.map(&:user)
   end
 
   def active_bot?

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -1,14 +1,14 @@
 class AccountPolicy < ApplicationPolicy
   def show?
-    @account_user.administrator? || @account_user.agent?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
   def cache_keys?
-    @account_user.administrator? || @account_user.agent?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
   def limits?
-    @account_user.administrator? || @account_user.agent?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
   def update?

--- a/app/policies/agent_bot_policy.rb
+++ b/app/policies/agent_bot_policy.rb
@@ -1,6 +1,6 @@
 class AgentBotPolicy < ApplicationPolicy
   def index?
-    @account_user.administrator? || @account_user.agent?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
   def update?
@@ -8,7 +8,7 @@ class AgentBotPolicy < ApplicationPolicy
   end
 
   def show?
-    @account_user.administrator? || @account_user.agent?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
   def create?

--- a/app/policies/appointment_policy.rb
+++ b/app/policies/appointment_policy.rb
@@ -1,22 +1,22 @@
 class AppointmentPolicy < ApplicationPolicy
   def index?
-    @account_user.administrator?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
   def update?
-    @account_user.administrator?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
   def show?
-    @account_user.administrator?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
   def create?
-    @account_user.administrator?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
   def destroy?
-    @account_user.administrator?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
   def search?

--- a/app/policies/conversation_policy.rb
+++ b/app/policies/conversation_policy.rb
@@ -24,11 +24,11 @@ class ConversationPolicy < ApplicationPolicy
   def supervisor_can_view_conversation?
     return false unless account_user&.supervisor?
 
-    return true if inbox_access? || team_access?
-
+    # Supervisor solo ve conversaciones asignadas a sí mismo o a sus subordinados
     return false if record.assignee_id.blank?
 
-    account_user.all_subordinate_user_ids.include?(record.assignee_id)
+    record.assignee_id == user.id ||
+      account_user.all_subordinate_user_ids.include?(record.assignee_id)
   end
 
   def agent_bot?

--- a/app/policies/conversation_policy.rb
+++ b/app/policies/conversation_policy.rb
@@ -8,7 +8,7 @@ class ConversationPolicy < ApplicationPolicy
   end
 
   def show?
-    administrator? || agent_bot? || agent_can_view_conversation?
+    administrator? || agent_bot? || supervisor_can_view_conversation? || agent_can_view_conversation?
   end
 
   private
@@ -19,6 +19,16 @@ class ConversationPolicy < ApplicationPolicy
 
   def administrator?
     account_user&.administrator?
+  end
+
+  def supervisor_can_view_conversation?
+    return false unless account_user&.supervisor?
+
+    return true if inbox_access? || team_access?
+
+    return false if record.assignee_id.blank?
+
+    account_user.all_subordinate_user_ids.include?(record.assignee_id)
   end
 
   def agent_bot?

--- a/app/policies/conversation_policy.rb
+++ b/app/policies/conversation_policy.rb
@@ -24,7 +24,7 @@ class ConversationPolicy < ApplicationPolicy
   def supervisor_can_view_conversation?
     return false unless account_user&.supervisor?
 
-    # Supervisor solo ve conversaciones asignadas a sí mismo o a sus subordinados
+    # Supervisor only sees conversations assigned to themselves or their subordinates
     return false if record.assignee_id.blank?
 
     record.assignee_id == user.id ||

--- a/app/policies/custom_filter_policy.rb
+++ b/app/policies/custom_filter_policy.rb
@@ -1,21 +1,21 @@
 class CustomFilterPolicy < ApplicationPolicy
   def create?
-    @account_user.administrator? || @account_user.agent?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
   def show?
-    @account_user.administrator? || @account_user.agent?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
   def index?
-    @account_user.administrator? || @account_user.agent?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
   def update?
-    @account_user.administrator? || @account_user.agent?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
   def destroy?
-    @account_user.administrator? || @account_user.agent?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 end

--- a/app/policies/label_policy.rb
+++ b/app/policies/label_policy.rb
@@ -1,6 +1,6 @@
 class LabelPolicy < ApplicationPolicy
   def index?
-    @account_user.administrator? || @account_user.agent?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
   def update?

--- a/app/policies/product_medium_policy.rb
+++ b/app/policies/product_medium_policy.rb
@@ -1,5 +1,5 @@
 class ProductMediumPolicy < ApplicationPolicy
   def set_primary?
-    @account_user.administrator? || @account_user.agent?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 end

--- a/app/policies/survey_answer_policy.rb
+++ b/app/policies/survey_answer_policy.rb
@@ -8,7 +8,7 @@ class SurveyAnswerPolicy < ApplicationPolicy
   end
 
   def create?
-    @account_user.administrator? || @account_user.agent?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
   def update?

--- a/app/services/action_service.rb
+++ b/app/services/action_service.rb
@@ -83,9 +83,17 @@ class ActionService
 
   def agent_belongs_to_inbox?(agent_ids)
     member_ids = @conversation.inbox.members.pluck(:user_id)
-    assignable_agent_ids = member_ids + @account.administrators.ids
+    supervisor_ids = supervisors_for_inbox_ids(member_ids)
+    assignable_agent_ids = member_ids + @account.administrators.ids + supervisor_ids
 
     assignable_agent_ids.include?(agent_ids[0])
+  end
+
+  # Only include supervisors whose subordinates are members of the inbox
+  def supervisors_for_inbox_ids(member_ids)
+    @account.account_users.supervisor.select do |account_user|
+      (account_user.subordinate_user_ids & member_ids).any?
+    end.map(&:user_id)
   end
 
   def team_belongs_to_account?(team_ids)

--- a/app/services/conversations/permission_filter_service.rb
+++ b/app/services/conversations/permission_filter_service.rb
@@ -21,16 +21,11 @@ class Conversations::PermissionFilterService
   end
 
   def supervisor_accessible_conversations
-    own_inbox_ids = user.inboxes.where(account_id: account.id).pluck(:id)
     subordinate_ids = account_user.all_subordinate_user_ids
-    # Incluir al propio supervisor para ver sus conversaciones asignadas
+    # Supervisor solo ve conversaciones asignadas a sí mismo o a sus subordinados
     all_assignee_ids = subordinate_ids + [user.id]
 
-    conversations.where(
-      'inbox_id IN (?) OR assignee_id IN (?)',
-      own_inbox_ids,
-      all_assignee_ids
-    )
+    conversations.where(assignee_id: all_assignee_ids)
   end
 
   def account_user

--- a/app/services/conversations/permission_filter_service.rb
+++ b/app/services/conversations/permission_filter_service.rb
@@ -9,6 +9,7 @@ class Conversations::PermissionFilterService
 
   def perform
     return conversations if user_role == 'administrator'
+    return supervisor_accessible_conversations if user_role == 'supervisor'
 
     accessible_conversations
   end
@@ -17,6 +18,17 @@ class Conversations::PermissionFilterService
 
   def accessible_conversations
     conversations.where(inbox: user.inboxes.where(account_id: account.id))
+  end
+
+  def supervisor_accessible_conversations
+    own_inbox_ids = user.inboxes.where(account_id: account.id).pluck(:id)
+    subordinate_ids = account_user.all_subordinate_user_ids
+
+    conversations.where(
+      'inbox_id IN (?) OR assignee_id IN (?)',
+      own_inbox_ids,
+      subordinate_ids
+    )
   end
 
   def account_user

--- a/app/services/conversations/permission_filter_service.rb
+++ b/app/services/conversations/permission_filter_service.rb
@@ -23,11 +23,13 @@ class Conversations::PermissionFilterService
   def supervisor_accessible_conversations
     own_inbox_ids = user.inboxes.where(account_id: account.id).pluck(:id)
     subordinate_ids = account_user.all_subordinate_user_ids
+    # Incluir al propio supervisor para ver sus conversaciones asignadas
+    all_assignee_ids = subordinate_ids + [user.id]
 
     conversations.where(
       'inbox_id IN (?) OR assignee_id IN (?)',
       own_inbox_ids,
-      subordinate_ids
+      all_assignee_ids
     )
   end
 

--- a/app/services/conversations/permission_filter_service.rb
+++ b/app/services/conversations/permission_filter_service.rb
@@ -22,7 +22,7 @@ class Conversations::PermissionFilterService
 
   def supervisor_accessible_conversations
     subordinate_ids = account_user.all_subordinate_user_ids
-    # Supervisor solo ve conversaciones asignadas a sí mismo o a sus subordinados
+    # Supervisor only sees conversations assigned to themselves or their subordinates
     all_assignee_ids = subordinate_ids + [user.id]
 
     conversations.where(assignee_id: all_assignee_ids)

--- a/app/services/messages/mention_service.rb
+++ b/app/services/messages/mention_service.rb
@@ -40,8 +40,17 @@ class Messages::MentionService
   def valid_mentionable_user_ids
     @valid_mentionable_user_ids ||= begin
       inbox = message.inbox
-      inbox.account.administrators.pluck(:id) + inbox.members.pluck(:id)
+      member_ids = inbox.members.pluck(:id)
+      supervisor_ids = supervisors_for_inbox_ids(inbox.account, member_ids)
+      inbox.account.administrators.pluck(:id) + supervisor_ids + member_ids
     end
+  end
+
+  # Only include supervisors whose subordinates are members of the inbox
+  def supervisors_for_inbox_ids(account, member_ids)
+    account.account_users.supervisor.select do |account_user|
+      (account_user.subordinate_user_ids & member_ids).any?
+    end.map(&:user_id)
   end
 
   def filter_mentioned_ids_by_inbox

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -31,13 +31,29 @@ class SearchService
   end
 
   def filter_conversations
-    @conversations = current_account.conversations.where(inbox_id: accessable_inbox_ids)
+    @conversations = conversation_base_query
                                     .joins('INNER JOIN contacts ON conversations.contact_id = contacts.id')
                                     .where("cast(conversations.display_id as text) ILIKE :search OR contacts.name ILIKE :search OR contacts.email
                             ILIKE :search OR contacts.phone_number ILIKE :search OR contacts.identifier ILIKE :search", search: "%#{search_query}%")
                                     .order('conversations.created_at DESC')
                                     .page(params[:page])
                                     .per(15)
+  end
+
+  def conversation_base_query
+    if account_user.administrator?
+      current_account.conversations
+    elsif account_user.supervisor?
+      # Supervisor ve: sus inboxes + conversaciones asignadas a subordinados o a sí mismo
+      supervisor_assignee_ids = account_user.all_subordinate_user_ids + [current_user.id]
+      current_account.conversations.where(
+        'inbox_id IN (?) OR assignee_id IN (?)',
+        accessable_inbox_ids,
+        supervisor_assignee_ids
+      )
+    else
+      current_account.conversations.where(inbox_id: accessable_inbox_ids)
+    end
   end
 
   def filter_messages
@@ -90,13 +106,21 @@ class SearchService
   end
 
   def message_base_query
-    query = current_account.messages.where('created_at >= ?', 3.months.ago)
-    query = query.where(inbox_id: accessable_inbox_ids) unless should_skip_inbox_filtering?
-    query
-  end
+    base = current_account.messages.where('messages.created_at >= ?', 3.months.ago)
 
-  def should_skip_inbox_filtering?
-    account_user.administrator? || user_has_access_to_all_inboxes?
+    if account_user.administrator? || user_has_access_to_all_inboxes?
+      base
+    elsif account_user.supervisor?
+      # Supervisor ve mensajes de: sus inboxes + conversaciones asignadas a subordinados o a sí mismo
+      supervisor_assignee_ids = account_user.all_subordinate_user_ids + [current_user.id]
+      base.joins(:conversation).where(
+        'messages.inbox_id IN (?) OR conversations.assignee_id IN (?)',
+        accessable_inbox_ids,
+        supervisor_assignee_ids
+      )
+    else
+      base.where(inbox_id: accessable_inbox_ids)
+    end
   end
 
   def user_has_access_to_all_inboxes?
@@ -105,6 +129,14 @@ class SearchService
 
   def use_gin_search
     current_account.feature_enabled?('search_with_gin')
+  end
+
+  # Used by enterprise advanced_search (Elasticsearch)
+  # Note: For supervisor, advanced_search has limited support - only filters by inbox_ids
+  # The full supervisor filtering (including subordinate assignee conversations) is handled
+  # in message_base_query for non-advanced search
+  def should_skip_inbox_filtering?
+    account_user.administrator? || user_has_access_to_all_inboxes?
   end
 
   def filter_contacts

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -44,7 +44,7 @@ class SearchService
     if account_user.administrator?
       current_account.conversations
     elsif account_user.supervisor?
-      # Supervisor solo ve conversaciones asignadas a sí mismo o a sus subordinados
+      # Supervisor only sees conversations assigned to themselves or their subordinates
       supervisor_assignee_ids = account_user.all_subordinate_user_ids + [current_user.id]
       current_account.conversations.where(assignee_id: supervisor_assignee_ids)
     else
@@ -107,7 +107,7 @@ class SearchService
     if account_user.administrator?
       base
     elsif account_user.supervisor?
-      # Supervisor solo ve mensajes de conversaciones asignadas a sí mismo o a sus subordinados
+      # Supervisor only sees messages from conversations assigned to themselves or their subordinates
       supervisor_assignee_ids = account_user.all_subordinate_user_ids + [current_user.id]
       base.joins(:conversation).where(conversations: { assignee_id: supervisor_assignee_ids })
     elsif user_has_access_to_all_inboxes?
@@ -143,7 +143,7 @@ class SearchService
     if account_user.administrator?
       current_account.contacts
     elsif account_user.supervisor?
-      # Supervisor solo ve contactos con conversaciones asignadas a sí mismo o a sus subordinados
+      # Supervisor only sees contacts with conversations assigned to themselves or their subordinates
       supervisor_assignee_ids = account_user.all_subordinate_user_ids + [current_user.id]
       contact_ids = current_account.conversations
                                    .where(assignee_id: supervisor_assignee_ids)
@@ -151,7 +151,7 @@ class SearchService
                                    .uniq
       current_account.contacts.where(id: contact_ids)
     else
-      # Agentes ven todos los contactos de la cuenta
+      # Agents see all contacts in the account
       current_account.contacts
     end
   end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -104,12 +104,14 @@ class SearchService
   def message_base_query
     base = current_account.messages.where('messages.created_at >= ?', 3.months.ago)
 
-    if account_user.administrator? || user_has_access_to_all_inboxes?
+    if account_user.administrator?
       base
     elsif account_user.supervisor?
       # Supervisor solo ve mensajes de conversaciones asignadas a sí mismo o a sus subordinados
       supervisor_assignee_ids = account_user.all_subordinate_user_ids + [current_user.id]
       base.joins(:conversation).where(conversations: { assignee_id: supervisor_assignee_ids })
+    elsif user_has_access_to_all_inboxes?
+      base
     else
       base.where(inbox_id: accessable_inbox_ids)
     end
@@ -124,11 +126,8 @@ class SearchService
   end
 
   # Used by enterprise advanced_search (Elasticsearch)
-  # Note: For supervisor, advanced_search has limited support - only filters by inbox_ids
-  # The full supervisor filtering (including subordinate assignee conversations) is handled
-  # in message_base_query for non-advanced search
   def should_skip_inbox_filtering?
-    account_user.administrator? || user_has_access_to_all_inboxes?
+    account_user.administrator? || (!account_user.supervisor? && user_has_access_to_all_inboxes?)
   end
 
   def filter_contacts

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -44,13 +44,9 @@ class SearchService
     if account_user.administrator?
       current_account.conversations
     elsif account_user.supervisor?
-      # Supervisor ve: sus inboxes + conversaciones asignadas a subordinados o a sí mismo
+      # Supervisor solo ve conversaciones asignadas a sí mismo o a sus subordinados
       supervisor_assignee_ids = account_user.all_subordinate_user_ids + [current_user.id]
-      current_account.conversations.where(
-        'inbox_id IN (?) OR assignee_id IN (?)',
-        accessable_inbox_ids,
-        supervisor_assignee_ids
-      )
+      current_account.conversations.where(assignee_id: supervisor_assignee_ids)
     else
       current_account.conversations.where(inbox_id: accessable_inbox_ids)
     end
@@ -111,13 +107,9 @@ class SearchService
     if account_user.administrator? || user_has_access_to_all_inboxes?
       base
     elsif account_user.supervisor?
-      # Supervisor ve mensajes de: sus inboxes + conversaciones asignadas a subordinados o a sí mismo
+      # Supervisor solo ve mensajes de conversaciones asignadas a sí mismo o a sus subordinados
       supervisor_assignee_ids = account_user.all_subordinate_user_ids + [current_user.id]
-      base.joins(:conversation).where(
-        'messages.inbox_id IN (?) OR conversations.assignee_id IN (?)',
-        accessable_inbox_ids,
-        supervisor_assignee_ids
-      )
+      base.joins(:conversation).where(conversations: { assignee_id: supervisor_assignee_ids })
     else
       base.where(inbox_id: accessable_inbox_ids)
     end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -132,12 +132,29 @@ class SearchService
   end
 
   def filter_contacts
-    @contacts = current_account.contacts.where(
+    @contacts = contact_base_query.where(
       "name ILIKE :search OR email ILIKE :search OR phone_number
       ILIKE :search OR identifier ILIKE :search", search: "%#{search_query}%"
     ).resolved_contacts(
       use_crm_v2: current_account.feature_enabled?('crm_v2')
     ).order_on_last_activity_at('desc').page(params[:page]).per(15)
+  end
+
+  def contact_base_query
+    if account_user.administrator?
+      current_account.contacts
+    elsif account_user.supervisor?
+      # Supervisor solo ve contactos con conversaciones asignadas a sí mismo o a sus subordinados
+      supervisor_assignee_ids = account_user.all_subordinate_user_ids + [current_user.id]
+      contact_ids = current_account.conversations
+                                   .where(assignee_id: supervisor_assignee_ids)
+                                   .pluck(:contact_id)
+                                   .uniq
+      current_account.contacts.where(id: contact_ids)
+    else
+      # Agentes ven todos los contactos de la cuenta
+      current_account.contacts
+    end
   end
 
   def filter_articles

--- a/enterprise/app/models/sla_event.rb
+++ b/enterprise/app/models/sla_event.rb
@@ -63,8 +63,10 @@ class SlaEvent < ApplicationRecord
 
   def create_notifications
     notify_users = conversation.conversation_participants.map(&:user)
-    # Add all admins from the account to notify list
+    # Add all admins to notify list
     notify_users += account.administrators
+    # Add supervisors only if their subordinates include the assignee
+    notify_users += supervisors_for_conversation
     # Ensure conversation assignee is notified
     notify_users += [conversation.assignee] if conversation.assignee.present?
 
@@ -83,5 +85,15 @@ class SlaEvent < ApplicationRecord
         secondary_actor: sla_policy
       ).perform
     end
+  end
+
+  # Only notify supervisors whose subordinates include the conversation's assignee
+  def supervisors_for_conversation
+    return [] if conversation.assignee_id.blank?
+
+    account.account_users.supervisor.includes(:user).select do |account_user|
+      account_user.user_id == conversation.assignee_id ||
+        account_user.all_subordinate_user_ids.include?(conversation.assignee_id)
+    end.map(&:user)
   end
 end

--- a/enterprise/app/policies/sla_policy_policy.rb
+++ b/enterprise/app/policies/sla_policy_policy.rb
@@ -1,6 +1,6 @@
 class SlaPolicyPolicy < ApplicationPolicy
   def index?
-    @account_user.administrator? || @account_user.agent?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
   def update?
@@ -8,7 +8,7 @@ class SlaPolicyPolicy < ApplicationPolicy
   end
 
   def show?
-    @account_user.administrator? || @account_user.agent?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
   def create?

--- a/enterprise/app/services/captain/tools/base_service.rb
+++ b/enterprise/app/services/captain/tools/base_service.rb
@@ -48,6 +48,6 @@ class Captain::Tools::BaseService
     return account_user.custom_role.permissions.include?(permission) if account_user.custom_role.present?
 
     # Default permission for agents without custom roles
-    account_user.administrator? || account_user.agent?
+    account_user.administrator? || account_user.supervisor? || account_user.agent?
   end
 end

--- a/enterprise/app/services/captain/tools/base_tool.rb
+++ b/enterprise/app/services/captain/tools/base_tool.rb
@@ -21,6 +21,6 @@ class Captain::Tools::BaseTool < RubyLLM::Tool
 
     return account_user.custom_role.permissions.include?(permission) if account_user.custom_role.present?
 
-    account_user.administrator? || account_user.agent?
+    account_user.administrator? || account_user.supervisor? || account_user.agent?
   end
 end

--- a/enterprise/app/services/enterprise/search_service.rb
+++ b/enterprise/app/services/enterprise/search_service.rb
@@ -1,7 +1,19 @@
 module Enterprise::SearchService
   def advanced_search
-    where_conditions = { account_id: current_account.id  }
-    where_conditions[:inbox_id] = accessable_inbox_ids unless should_skip_inbox_filtering?
+    where_conditions = { account_id: current_account.id }
+
+    unless should_skip_inbox_filtering?
+      if account_user.supervisor?
+        # Supervisor solo ve mensajes de conversaciones asignadas a sí mismo o a sus subordinados
+        supervisor_assignee_ids = account_user.all_subordinate_user_ids + [current_user.id]
+        conversation_ids = current_account.conversations
+                                          .where(assignee_id: supervisor_assignee_ids)
+                                          .pluck(:id)
+        where_conditions[:conversation_id] = conversation_ids
+      else
+        where_conditions[:inbox_id] = accessable_inbox_ids
+      end
+    end
 
     Message.search(
       search_query,

--- a/enterprise/app/services/enterprise/search_service.rb
+++ b/enterprise/app/services/enterprise/search_service.rb
@@ -4,7 +4,7 @@ module Enterprise::SearchService
 
     unless should_skip_inbox_filtering?
       if account_user.supervisor?
-        # Supervisor solo ve mensajes de conversaciones asignadas a sí mismo o a sus subordinados
+        # Supervisor only sees messages from conversations assigned to themselves or their subordinates
         supervisor_assignee_ids = account_user.all_subordinate_user_ids + [current_user.id]
         conversation_ids = current_account.conversations
                                           .where(assignee_id: supervisor_assignee_ids)


### PR DESCRIPTION
## Description

Added a new "Supervisor" role that provides hierarchical team management with scoped visibility.

  Key Features

  - Hierarchical structure: Supervisors can only view and manage conversations assigned to themselves or their subordinates (agents with responsible_id pointing to the supervisor)
  - Multi-level hierarchy: Supports nested supervision (supervisor → supervisor → agent)
  - Strict data isolation: Supervisors cannot see conversations, contacts, appointments, or messages from agents outside their hierarchy
  - Filtered search: All search endpoints (messages, conversations, contacts) respect supervisor visibility rules
  - Scoped notifications: SLA alerts and mentions only notify relevant supervisors based on conversation assignee hierarchy
  - WebSocket filtering: Real-time updates are filtered to only broadcast to supervisors with visibility rights

  Business Rules

  - Supervisor sees: own conversations + subordinates' conversations
  - Supervisor does NOT see: unassigned conversations or conversations from non-subordinates
  - Subordinates are defined by AccountUser.responsible_id relationship