### PR TITLE
feat: kb webhooks

### DIFF
--- a/app/controllers/api/v1/accounts/product_catalogs_controller.rb
+++ b/app/controllers/api/v1/accounts/product_catalogs_controller.rb
@@ -161,30 +161,8 @@ class Api::V1::Accounts::ProductCatalogsController < Api::V1::Accounts::BaseCont
       return
     end
 
-    # Get products to delete and their product_ids for webhook payload
-    products_to_delete = Current.account.product_catalogs.where(id: ids)
-    deleted_product_ids = products_to_delete.pluck(:product_id)
-
-    # Skip individual callbacks, we'll dispatch one bulk event
-    deleted_count = 0
-    products_to_delete.find_each do |product|
-      product.skip_catalog_callbacks = true
-      product.destroy
-      deleted_count += 1
-    end
-
-    # Dispatch one bulk event
-    Rails.configuration.dispatcher.dispatch(
-      PRODUCT_CATALOG_UPDATED,
-      Time.zone.now,
-      account: Current.account,
-      added_count: 0,
-      updated_count: 0,
-      deleted_count: deleted_count,
-      added_product_ids: [],
-      updated_product_ids: [],
-      deleted_product_ids: deleted_product_ids
-    )
+    deleted_product_ids, deleted_count = destroy_products_with_skip_callbacks(ids)
+    dispatch_bulk_delete_event(deleted_product_ids, deleted_count)
 
     head :ok
   end
@@ -401,4 +379,31 @@ class Api::V1::Accounts::ProductCatalogsController < Api::V1::Accounts::BaseCont
     end
   end
 
+  def destroy_products_with_skip_callbacks(ids)
+    products_to_delete = Current.account.product_catalogs.where(id: ids)
+    deleted_product_ids = products_to_delete.pluck(:product_id)
+
+    deleted_count = 0
+    products_to_delete.find_each do |product|
+      product.skip_catalog_callbacks = true
+      product.destroy
+      deleted_count += 1
+    end
+
+    [deleted_product_ids, deleted_count]
+  end
+
+  def dispatch_bulk_delete_event(deleted_product_ids, deleted_count)
+    Rails.configuration.dispatcher.dispatch(
+      PRODUCT_CATALOG_UPDATED,
+      Time.zone.now,
+      account: Current.account,
+      added_count: 0,
+      updated_count: 0,
+      deleted_count: deleted_count,
+      added_product_ids: [],
+      updated_product_ids: [],
+      deleted_product_ids: deleted_product_ids
+    )
+  end
 end

--- a/app/controllers/api/v1/accounts/product_catalogs_controller.rb
+++ b/app/controllers/api/v1/accounts/product_catalogs_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::Accounts::ProductCatalogsController < Api::V1::Accounts::BaseController
+  include Events::Types
+
   before_action :product_catalog, except: [:index, :create, :bulk_upload, :bulk_delete, :export, :export_all, :download_export, :download_template]
   before_action :check_authorization
   before_action :check_rate_limit, only: [:bulk_upload, :export_all]
@@ -159,8 +161,30 @@ class Api::V1::Accounts::ProductCatalogsController < Api::V1::Accounts::BaseCont
       return
     end
 
-    # Delete products
-    Current.account.product_catalogs.where(id: ids).destroy_all
+    # Get products to delete and their product_ids for webhook payload
+    products_to_delete = Current.account.product_catalogs.where(id: ids)
+    deleted_product_ids = products_to_delete.pluck(:product_id)
+
+    # Skip individual callbacks, we'll dispatch one bulk event
+    deleted_count = 0
+    products_to_delete.find_each do |product|
+      product.skip_catalog_callbacks = true
+      product.destroy
+      deleted_count += 1
+    end
+
+    # Dispatch one bulk event
+    Rails.configuration.dispatcher.dispatch(
+      PRODUCT_CATALOG_UPDATED,
+      Time.zone.now,
+      account: Current.account,
+      added_count: 0,
+      updated_count: 0,
+      deleted_count: deleted_count,
+      added_product_ids: [],
+      updated_product_ids: [],
+      deleted_product_ids: deleted_product_ids
+    )
 
     head :ok
   end
@@ -376,4 +400,5 @@ class Api::V1::Accounts::ProductCatalogsController < Api::V1::Accounts::BaseCont
       }, status: :too_many_requests
     end
   end
+
 end

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -44,7 +44,9 @@
             "CONTACT_UPDATED": "Contact updated",
             "CONVERSATION_TYPING_ON": "Conversation Typing On",
             "CONVERSATION_TYPING_OFF": "Conversation Typing Off",
-            "AGENT_ADDED": "Agent Created"
+            "AGENT_ADDED": "Agent Created",
+            "FAQ_CATALOG_UPDATED": "FAQ Catalog Updated",
+            "PRODUCT_CATALOG_UPDATED": "Product Catalog Updated"
           }
         },
         "NAME": {

--- a/app/javascript/dashboard/i18n/locale/es/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/es/integrations.json
@@ -44,7 +44,9 @@
             "CONTACT_UPDATED": "Contacto actualizado",
             "CONVERSATION_TYPING_ON": "Conversation Typing On",
             "CONVERSATION_TYPING_OFF": "Conversation Typing Off",
-            "AGENT_ADDED": "Agente Creado"
+            "AGENT_ADDED": "Agente Creado",
+            "FAQ_CATALOG_UPDATED": "Catálogo de FAQs Actualizado",
+            "PRODUCT_CATALOG_UPDATED": "Catálogo de Productos Actualizado"
           }
         },
         "NAME": {

--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookForm.vue
@@ -19,6 +19,9 @@ const SUPPORTED_WEBHOOK_EVENTS = [
   'conversation_typing_on',
   'conversation_typing_off',
   'agent_added',
+  // Catalog bulk events
+  'faq_catalog_updated',
+  'product_catalog_updated',
 ];
 
 export default {

--- a/app/jobs/product_catalogs/process_bulk_upload_job.rb
+++ b/app/jobs/product_catalogs/process_bulk_upload_job.rb
@@ -1,4 +1,6 @@
 class ProductCatalogs::ProcessBulkUploadJob < ApplicationJob
+  include Events::Types
+
   queue_as :high
   retry_on ActiveStorage::FileNotFoundError, wait: 1.minute, attempts: 3
 
@@ -28,6 +30,9 @@ class ProductCatalogs::ProcessBulkUploadJob < ApplicationJob
     end
 
     @bulk_request.update!(status: 'PROCESSING')
+
+    # Capture existing product_ids before processing to track adds vs updates
+    @existing_product_ids_before = @account.product_catalogs.pluck(:product_id).to_set
 
     # Phase 1: Process Excel file (0-50% progress)
     excel_result = process_excel(@file_path)
@@ -243,6 +248,20 @@ class ProductCatalogs::ProcessBulkUploadJob < ApplicationJob
   def update_final_status(excel_result, media_result)
     # If both phases succeeded
     if excel_result[:success] && media_result[:success]
+      # Get products processed in this bulk request and categorize as added vs updated
+      processed_products = @bulk_request.product_catalogs.pluck(:product_id)
+
+      added_product_ids = []
+      updated_product_ids = []
+
+      processed_products.each do |product_id|
+        if @existing_product_ids_before&.include?(product_id)
+          updated_product_ids << product_id
+        else
+          added_product_ids << product_id
+        end
+      end
+
       # Check if all records were processed successfully
       if @bulk_request.failed_records.zero? && @bulk_request.processed_records.positive?
         @bulk_request.update!(
@@ -250,12 +269,28 @@ class ProductCatalogs::ProcessBulkUploadJob < ApplicationJob
           progress: 100.0,
           error_message: nil
         )
+        dispatch_catalog_updated_event(
+          added_count: added_product_ids.size,
+          updated_count: updated_product_ids.size,
+          deleted_count: 0,
+          added_product_ids: added_product_ids,
+          updated_product_ids: updated_product_ids,
+          deleted_product_ids: []
+        )
       elsif @bulk_request.failed_records.positive? && @bulk_request.processed_records.positive?
         # Some records succeeded, some failed
         @bulk_request.update!(
           status: 'PARTIALLY_COMPLETED',
           progress: 100.0,
           error_message: "Processed #{@bulk_request.processed_records} of #{@bulk_request.total_records} records. #{@bulk_request.failed_records} failed."
+        )
+        dispatch_catalog_updated_event(
+          added_count: added_product_ids.size,
+          updated_count: updated_product_ids.size,
+          deleted_count: 0,
+          added_product_ids: added_product_ids,
+          updated_product_ids: updated_product_ids,
+          deleted_product_ids: []
         )
       else
         # No records were processed
@@ -277,6 +312,20 @@ class ProductCatalogs::ProcessBulkUploadJob < ApplicationJob
         error_message: error_msg.join('; ')
       )
     end
+  end
+
+  def dispatch_catalog_updated_event(added_count:, updated_count:, deleted_count:, added_product_ids:, updated_product_ids:, deleted_product_ids:)
+    Rails.configuration.dispatcher.dispatch(
+      PRODUCT_CATALOG_UPDATED,
+      Time.zone.now,
+      account: @account,
+      added_count: added_count,
+      updated_count: updated_count,
+      deleted_count: deleted_count,
+      added_product_ids: added_product_ids,
+      updated_product_ids: updated_product_ids,
+      deleted_product_ids: deleted_product_ids
+    )
   end
 
   def handle_error(error)

--- a/app/jobs/product_catalogs/process_bulk_upload_job.rb
+++ b/app/jobs/product_catalogs/process_bulk_upload_job.rb
@@ -246,72 +246,79 @@ class ProductCatalogs::ProcessBulkUploadJob < ApplicationJob
   end
 
   def update_final_status(excel_result, media_result)
-    # If both phases succeeded
     if excel_result[:success] && media_result[:success]
-      # Get products processed in this bulk request and categorize as added vs updated
-      processed_products = @bulk_request.product_catalogs.pluck(:product_id)
-
-      added_product_ids = []
-      updated_product_ids = []
-
-      processed_products.each do |product_id|
-        if @existing_product_ids_before&.include?(product_id)
-          updated_product_ids << product_id
-        else
-          added_product_ids << product_id
-        end
-      end
-
-      # Check if all records were processed successfully
-      if @bulk_request.failed_records.zero? && @bulk_request.processed_records.positive?
-        @bulk_request.update!(
-          status: 'COMPLETED',
-          progress: 100.0,
-          error_message: nil
-        )
-        dispatch_catalog_updated_event(
-          added_count: added_product_ids.size,
-          updated_count: updated_product_ids.size,
-          deleted_count: 0,
-          added_product_ids: added_product_ids,
-          updated_product_ids: updated_product_ids,
-          deleted_product_ids: []
-        )
-      elsif @bulk_request.failed_records.positive? && @bulk_request.processed_records.positive?
-        # Some records succeeded, some failed
-        @bulk_request.update!(
-          status: 'PARTIALLY_COMPLETED',
-          progress: 100.0,
-          error_message: "Processed #{@bulk_request.processed_records} of #{@bulk_request.total_records} records. #{@bulk_request.failed_records} failed."
-        )
-        dispatch_catalog_updated_event(
-          added_count: added_product_ids.size,
-          updated_count: updated_product_ids.size,
-          deleted_count: 0,
-          added_product_ids: added_product_ids,
-          updated_product_ids: updated_product_ids,
-          deleted_product_ids: []
-        )
-      else
-        # No records were processed
-        @bulk_request.update!(
-          status: 'FAILED',
-          progress: 0.0,
-          error_message: 'No records were processed successfully'
-        )
-      end
+      handle_successful_processing
     else
-      # One of the phases failed
-      error_msg = []
-      error_msg << "Excel: #{excel_result[:error]}" unless excel_result[:success]
-      error_msg << "Media: #{media_result[:error]}" unless media_result[:success]
-
-      @bulk_request.update!(
-        status: 'FAILED',
-        progress: 0.0,
-        error_message: error_msg.join('; ')
-      )
+      handle_failed_processing(excel_result, media_result)
     end
+  end
+
+  def handle_successful_processing
+    added_product_ids, updated_product_ids = categorize_processed_products
+
+    if @bulk_request.failed_records.zero? && @bulk_request.processed_records.positive?
+      complete_bulk_request(added_product_ids, updated_product_ids)
+    elsif @bulk_request.failed_records.positive? && @bulk_request.processed_records.positive?
+      partially_complete_bulk_request(added_product_ids, updated_product_ids)
+    else
+      fail_bulk_request('No records were processed successfully')
+    end
+  end
+
+  def categorize_processed_products
+    processed_products = @bulk_request.product_catalogs.pluck(:product_id)
+    added_product_ids = []
+    updated_product_ids = []
+
+    processed_products.each do |product_id|
+      if @existing_product_ids_before&.include?(product_id)
+        updated_product_ids << product_id
+      else
+        added_product_ids << product_id
+      end
+    end
+
+    [added_product_ids, updated_product_ids]
+  end
+
+  def complete_bulk_request(added_product_ids, updated_product_ids)
+    @bulk_request.update!(status: 'COMPLETED', progress: 100.0, error_message: nil)
+    dispatch_catalog_updated_event(
+      added_count: added_product_ids.size,
+      updated_count: updated_product_ids.size,
+      deleted_count: 0,
+      added_product_ids: added_product_ids,
+      updated_product_ids: updated_product_ids,
+      deleted_product_ids: []
+    )
+  end
+
+  def partially_complete_bulk_request(added_product_ids, updated_product_ids)
+    @bulk_request.update!(
+      status: 'PARTIALLY_COMPLETED',
+      progress: 100.0,
+      error_message: "Processed #{@bulk_request.processed_records} of #{@bulk_request.total_records} records. #{@bulk_request.failed_records} failed."
+    )
+    dispatch_catalog_updated_event(
+      added_count: added_product_ids.size,
+      updated_count: updated_product_ids.size,
+      deleted_count: 0,
+      added_product_ids: added_product_ids,
+      updated_product_ids: updated_product_ids,
+      deleted_product_ids: []
+    )
+  end
+
+  def fail_bulk_request(error_message)
+    @bulk_request.update!(status: 'FAILED', progress: 0.0, error_message: error_message)
+  end
+
+  def handle_failed_processing(excel_result, media_result)
+    error_msg = []
+    error_msg << "Excel: #{excel_result[:error]}" unless excel_result[:success]
+    error_msg << "Media: #{media_result[:error]}" unless media_result[:success]
+
+    fail_bulk_request(error_msg.join('; '))
   end
 
   def dispatch_catalog_updated_event(added_count:, updated_count:, deleted_count:, added_product_ids:, updated_product_ids:, deleted_product_ids:)

--- a/app/listeners/webhook_listener.rb
+++ b/app/listeners/webhook_listener.rb
@@ -108,6 +108,58 @@ class WebhookListener < BaseListener
     deliver_account_webhooks(payload, account, idempotency_key)
   end
 
+  # FAQ catalog bulk event
+  def faq_catalog_updated(event)
+    account = event.data[:account]
+    added_count = event.data[:added_count] || 0
+    updated_count = event.data[:updated_count] || 0
+    deleted_count = event.data[:deleted_count] || 0
+    added_faq_items = event.data[:added_faq_items] || []
+    updated_faq_items = event.data[:updated_faq_items] || []
+    deleted_faq_items = event.data[:deleted_faq_items] || []
+
+    idempotency_key = SecureRandom.uuid
+    payload = {
+      event: __method__.to_s,
+      timestamp: Time.zone.now.iso8601,
+      account: account.webhook_data,
+      added_count: added_count,
+      updated_count: updated_count,
+      deleted_count: deleted_count,
+      added_faq_items: added_faq_items,
+      updated_faq_items: updated_faq_items,
+      deleted_faq_items: deleted_faq_items,
+      idempotency_key: idempotency_key
+    }
+    deliver_account_webhooks(payload, account, idempotency_key)
+  end
+
+  # Product catalog bulk event
+  def product_catalog_updated(event)
+    account = event.data[:account]
+    added_count = event.data[:added_count] || 0
+    updated_count = event.data[:updated_count] || 0
+    deleted_count = event.data[:deleted_count] || 0
+    added_product_ids = event.data[:added_product_ids] || []
+    updated_product_ids = event.data[:updated_product_ids] || []
+    deleted_product_ids = event.data[:deleted_product_ids] || []
+
+    idempotency_key = SecureRandom.uuid
+    payload = {
+      event: __method__.to_s,
+      timestamp: Time.zone.now.iso8601,
+      account: account.webhook_data,
+      added_count: added_count,
+      updated_count: updated_count,
+      deleted_count: deleted_count,
+      added_product_ids: added_product_ids,
+      updated_product_ids: updated_product_ids,
+      deleted_product_ids: deleted_product_ids,
+      idempotency_key: idempotency_key
+    }
+    deliver_account_webhooks(payload, account, idempotency_key)
+  end
+
   private
 
   def handle_typing_status(event_name, event)

--- a/app/models/faq_category.rb
+++ b/app/models/faq_category.rb
@@ -1,11 +1,13 @@
 class FaqCategory < ApplicationRecord
+  include Events::Types
+
   belongs_to :account
   belongs_to :parent, class_name: 'FaqCategory', optional: true
   belongs_to :created_by, class_name: 'User', optional: true
   belongs_to :updated_by, class_name: 'User', optional: true
 
   has_many :children, class_name: 'FaqCategory', foreign_key: :parent_id, dependent: :destroy
-  has_many :faq_items, dependent: :destroy
+  has_many :faq_items, dependent: nil # Handled manually to send bulk webhook
   has_many :inbox_faq_categories, dependent: :destroy
   has_many :inboxes, through: :inbox_faq_categories
 
@@ -18,6 +20,9 @@ class FaqCategory < ApplicationRecord
   # Validate max depth of 2 levels
   validate :validate_max_depth
 
+  before_destroy :destroy_faq_items_with_skip_callbacks
+  after_destroy_commit :dispatch_bulk_faq_deleted_event
+
   private
 
   def validate_max_depth
@@ -26,5 +31,33 @@ class FaqCategory < ApplicationRecord
     if parent&.parent_id.present?
       errors.add(:parent_id, 'cannot have more than 2 levels of nesting')
     end
+  end
+
+  def destroy_faq_items_with_skip_callbacks
+    @cached_deleted_faq_items = faq_items.pluck(:id, :faq_category_id).map do |item_id, cat_id|
+      { id: item_id, faq_category_id: cat_id }
+    end
+    @cached_account = account
+
+    faq_items.find_each do |item|
+      item.skip_catalog_callbacks = true
+      item.destroy
+    end
+  end
+
+  def dispatch_bulk_faq_deleted_event
+    return if @cached_deleted_faq_items.blank?
+
+    Rails.configuration.dispatcher.dispatch(
+      FAQ_CATALOG_UPDATED,
+      Time.zone.now,
+      account: @cached_account,
+      added_count: 0,
+      updated_count: 0,
+      deleted_count: @cached_deleted_faq_items.size,
+      added_faq_items: [],
+      updated_faq_items: [],
+      deleted_faq_items: @cached_deleted_faq_items
+    )
   end
 end

--- a/app/models/faq_item.rb
+++ b/app/models/faq_item.rb
@@ -1,10 +1,20 @@
 class FaqItem < ApplicationRecord
+  include Events::Types
+
   belongs_to :account
   belongs_to :faq_category, optional: true
   belongs_to :created_by, class_name: 'User', optional: true
   belongs_to :updated_by, class_name: 'User', optional: true
 
   validate :has_at_least_one_translation
+
+  # Skip callbacks for bulk operations (handled separately in controllers)
+  attr_accessor :skip_catalog_callbacks
+
+  before_destroy :cache_destroy_data
+  after_create_commit :dispatch_create_event, unless: :skip_catalog_callbacks
+  after_update_commit :dispatch_update_event, unless: :skip_catalog_callbacks
+  after_destroy_commit :dispatch_destroy_event, unless: :skip_catalog_callbacks
 
   scope :ordered, -> { order(position: :asc, created_at: :asc) }
   scope :visible, -> { where(is_visible: true) }
@@ -29,5 +39,55 @@ class FaqItem < ApplicationRecord
     return if translations.present? && translations.values.any? { |t| t['question'].present? }
 
     errors.add(:translations, 'must have at least one question')
+  end
+
+  def cache_destroy_data
+    @cached_destroy_data = {
+      id: id,
+      faq_category_id: faq_category_id,
+      account: account
+    }
+  end
+
+  def dispatch_create_event
+    Rails.configuration.dispatcher.dispatch(
+      FAQ_CATALOG_UPDATED,
+      Time.zone.now,
+      account: account,
+      added_count: 1,
+      updated_count: 0,
+      deleted_count: 0,
+      added_faq_items: [{ id: id, faq_category_id: faq_category_id }],
+      updated_faq_items: [],
+      deleted_faq_items: []
+    )
+  end
+
+  def dispatch_update_event
+    Rails.configuration.dispatcher.dispatch(
+      FAQ_CATALOG_UPDATED,
+      Time.zone.now,
+      account: account,
+      added_count: 0,
+      updated_count: 1,
+      deleted_count: 0,
+      added_faq_items: [],
+      updated_faq_items: [{ id: id, faq_category_id: faq_category_id }],
+      deleted_faq_items: []
+    )
+  end
+
+  def dispatch_destroy_event
+    Rails.configuration.dispatcher.dispatch(
+      FAQ_CATALOG_UPDATED,
+      Time.zone.now,
+      account: @cached_destroy_data[:account],
+      added_count: 0,
+      updated_count: 0,
+      deleted_count: 1,
+      added_faq_items: [],
+      updated_faq_items: [],
+      deleted_faq_items: [{ id: @cached_destroy_data[:id], faq_category_id: @cached_destroy_data[:faq_category_id] }]
+    )
   end
 end

--- a/app/models/faq_item.rb
+++ b/app/models/faq_item.rb
@@ -11,7 +11,6 @@ class FaqItem < ApplicationRecord
   # Skip callbacks for bulk operations (handled separately in controllers)
   attr_accessor :skip_catalog_callbacks
 
-  before_destroy :cache_destroy_data
   after_create_commit :dispatch_create_event, unless: :skip_catalog_callbacks
   after_update_commit :dispatch_update_event, unless: :skip_catalog_callbacks
   after_destroy_commit :dispatch_destroy_event, unless: :skip_catalog_callbacks
@@ -41,53 +40,33 @@ class FaqItem < ApplicationRecord
     errors.add(:translations, 'must have at least one question')
   end
 
-  def cache_destroy_data
-    @cached_destroy_data = {
-      id: id,
-      faq_category_id: faq_category_id,
-      account: account
-    }
+  def faq_item_payload
+    { id: id, faq_category_id: faq_category_id }
+  end
+
+  def dispatch_faq_event(target_account:, added: 0, updated: 0, deleted: 0, added_items: [], updated_items: [], deleted_items: [])
+    Rails.configuration.dispatcher.dispatch(
+      FAQ_CATALOG_UPDATED,
+      Time.zone.now,
+      account: target_account,
+      added_count: added,
+      updated_count: updated,
+      deleted_count: deleted,
+      added_faq_items: added_items,
+      updated_faq_items: updated_items,
+      deleted_faq_items: deleted_items
+    )
   end
 
   def dispatch_create_event
-    Rails.configuration.dispatcher.dispatch(
-      FAQ_CATALOG_UPDATED,
-      Time.zone.now,
-      account: account,
-      added_count: 1,
-      updated_count: 0,
-      deleted_count: 0,
-      added_faq_items: [{ id: id, faq_category_id: faq_category_id }],
-      updated_faq_items: [],
-      deleted_faq_items: []
-    )
+    dispatch_faq_event(target_account: account, added: 1, added_items: [faq_item_payload])
   end
 
   def dispatch_update_event
-    Rails.configuration.dispatcher.dispatch(
-      FAQ_CATALOG_UPDATED,
-      Time.zone.now,
-      account: account,
-      added_count: 0,
-      updated_count: 1,
-      deleted_count: 0,
-      added_faq_items: [],
-      updated_faq_items: [{ id: id, faq_category_id: faq_category_id }],
-      deleted_faq_items: []
-    )
+    dispatch_faq_event(target_account: account, updated: 1, updated_items: [faq_item_payload])
   end
 
   def dispatch_destroy_event
-    Rails.configuration.dispatcher.dispatch(
-      FAQ_CATALOG_UPDATED,
-      Time.zone.now,
-      account: @cached_destroy_data[:account],
-      added_count: 0,
-      updated_count: 0,
-      deleted_count: 1,
-      added_faq_items: [],
-      updated_faq_items: [],
-      deleted_faq_items: [{ id: @cached_destroy_data[:id], faq_category_id: @cached_destroy_data[:faq_category_id] }]
-    )
+    dispatch_faq_event(target_account: account, deleted: 1, deleted_items: [faq_item_payload])
   end
 end

--- a/app/models/product_catalog.rb
+++ b/app/models/product_catalog.rb
@@ -82,7 +82,6 @@ class ProductCatalog < ApplicationRecord
   # Skip callbacks for bulk operations (handled separately in jobs/controllers)
   attr_accessor :skip_catalog_callbacks
 
-  before_destroy :cache_destroy_data
   after_create_commit :dispatch_create_event, unless: :skip_catalog_callbacks
   after_update_commit :dispatch_update_event, unless: :skip_catalog_callbacks
   after_destroy_commit :dispatch_destroy_event, unless: :skip_catalog_callbacks
@@ -126,53 +125,30 @@ class ProductCatalog < ApplicationRecord
     errors.add(:payment_options, "contains invalid options: #{invalid_options.join(', ')}")
   end
 
-  def cache_destroy_data
-    @cached_destroy_data = {
-      product_id: product_id,
-      account: account
-    }
+  def dispatch_product_event(target_account:, added: 0, updated: 0, deleted: 0, added_ids: [], updated_ids: [], deleted_ids: [])
+    Rails.configuration.dispatcher.dispatch(
+      PRODUCT_CATALOG_UPDATED,
+      Time.zone.now,
+      account: target_account,
+      added_count: added,
+      updated_count: updated,
+      deleted_count: deleted,
+      added_product_ids: added_ids,
+      updated_product_ids: updated_ids,
+      deleted_product_ids: deleted_ids
+    )
   end
 
   def dispatch_create_event
-    Rails.configuration.dispatcher.dispatch(
-      PRODUCT_CATALOG_UPDATED,
-      Time.zone.now,
-      account: account,
-      added_count: 1,
-      updated_count: 0,
-      deleted_count: 0,
-      added_product_ids: [product_id],
-      updated_product_ids: [],
-      deleted_product_ids: []
-    )
+    dispatch_product_event(target_account: account, added: 1, added_ids: [product_id])
   end
 
   def dispatch_update_event
-    Rails.configuration.dispatcher.dispatch(
-      PRODUCT_CATALOG_UPDATED,
-      Time.zone.now,
-      account: account,
-      added_count: 0,
-      updated_count: 1,
-      deleted_count: 0,
-      added_product_ids: [],
-      updated_product_ids: [product_id],
-      deleted_product_ids: []
-    )
+    dispatch_product_event(target_account: account, updated: 1, updated_ids: [product_id])
   end
 
   def dispatch_destroy_event
-    Rails.configuration.dispatcher.dispatch(
-      PRODUCT_CATALOG_UPDATED,
-      Time.zone.now,
-      account: @cached_destroy_data[:account],
-      added_count: 0,
-      updated_count: 0,
-      deleted_count: 1,
-      added_product_ids: [],
-      updated_product_ids: [],
-      deleted_product_ids: [@cached_destroy_data[:product_id]]
-    )
+    dispatch_product_event(target_account: account, deleted: 1, deleted_ids: [product_id])
   end
 end
 

--- a/app/models/product_catalog.rb
+++ b/app/models/product_catalog.rb
@@ -41,6 +41,7 @@
 #
 class ProductCatalog < ApplicationRecord
   include PgSearch::Model
+  include Events::Types
 
   # Disable Single Table Inheritance (STI) to allow 'type' column for product type
   self.inheritance_column = :_type_disabled
@@ -77,6 +78,14 @@ class ProductCatalog < ApplicationRecord
   validates :listPrice, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
 
   validate :validate_payment_options
+
+  # Skip callbacks for bulk operations (handled separately in jobs/controllers)
+  attr_accessor :skip_catalog_callbacks
+
+  before_destroy :cache_destroy_data
+  after_create_commit :dispatch_create_event, unless: :skip_catalog_callbacks
+  after_update_commit :dispatch_update_event, unless: :skip_catalog_callbacks
+  after_destroy_commit :dispatch_destroy_event, unless: :skip_catalog_callbacks
 
   scope :by_industry, ->(industry) { where(industry: industry) }
   scope :by_type, ->(type) { where(type: type) }
@@ -115,6 +124,55 @@ class ProductCatalog < ApplicationRecord
     return if invalid_options.empty?
 
     errors.add(:payment_options, "contains invalid options: #{invalid_options.join(', ')}")
+  end
+
+  def cache_destroy_data
+    @cached_destroy_data = {
+      product_id: product_id,
+      account: account
+    }
+  end
+
+  def dispatch_create_event
+    Rails.configuration.dispatcher.dispatch(
+      PRODUCT_CATALOG_UPDATED,
+      Time.zone.now,
+      account: account,
+      added_count: 1,
+      updated_count: 0,
+      deleted_count: 0,
+      added_product_ids: [product_id],
+      updated_product_ids: [],
+      deleted_product_ids: []
+    )
+  end
+
+  def dispatch_update_event
+    Rails.configuration.dispatcher.dispatch(
+      PRODUCT_CATALOG_UPDATED,
+      Time.zone.now,
+      account: account,
+      added_count: 0,
+      updated_count: 1,
+      deleted_count: 0,
+      added_product_ids: [],
+      updated_product_ids: [product_id],
+      deleted_product_ids: []
+    )
+  end
+
+  def dispatch_destroy_event
+    Rails.configuration.dispatcher.dispatch(
+      PRODUCT_CATALOG_UPDATED,
+      Time.zone.now,
+      account: @cached_destroy_data[:account],
+      added_count: 0,
+      updated_count: 0,
+      deleted_count: 1,
+      added_product_ids: [],
+      updated_product_ids: [],
+      deleted_product_ids: [@cached_destroy_data[:product_id]]
+    )
   end
 end
 

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -28,7 +28,8 @@ class Webhook < ApplicationRecord
 
   ALLOWED_WEBHOOK_EVENTS = %w[conversation_status_changed conversation_updated conversation_created contact_created contact_updated
                               message_created message_updated webwidget_triggered inbox_created inbox_updated
-                              conversation_typing_on conversation_typing_off agent_added].freeze
+                              conversation_typing_on conversation_typing_off agent_added
+                              faq_catalog_updated product_catalog_updated].freeze
 
   private
 

--- a/lib/events/types.rb
+++ b/lib/events/types.rb
@@ -61,4 +61,10 @@ module Events::Types
 
   # copilot events
   COPILOT_MESSAGE_CREATED = 'copilot.message.created'
+
+  # FAQ Catalog events (bulk)
+  FAQ_CATALOG_UPDATED = 'faq_catalog.updated'
+
+  # Product Catalog events (bulk)
+  PRODUCT_CATALOG_UPDATED = 'product_catalog.updated'
 end


### PR DESCRIPTION
Implement webhook notifications for knowledge base changes (products and FAQs). Events are dispatched from model callbacks after database commit.

## Events

- `product_catalog_updated`: Triggered on product create/update/delete
- `faq_catalog_updated`: Triggered on FAQ item create/update/delete

## Webhook Payload Examples

### product_catalog_updated
```json
{
  "event": "product_catalog_updated",
  "timestamp": "2025-01-22T10:30:00-06:00",
  "account": { "id": 1, "name": "..." },
  "added_count": 1,
  "updated_count": 0,
  "deleted_count": 0,
  "added_product_ids": ["PROD-001"],
  "updated_product_ids": [],
  "deleted_product_ids": [],
  "idempotency_key": "uuid"
}
```

### faq_catalog_updated
```json
{
  "event": "faq_catalog_updated",
  "timestamp": "2025-01-22T10:30:00-06:00",
  "account": { "id": 1, "name": "..." },
  "added_count": 0,
  "updated_count": 0,
  "deleted_count": 2,
  "added_faq_items": [],
  "updated_faq_items": [],
  "deleted_faq_items": [
    { "id": 10, "faq_category_id": 5 },
    { "id": 11, "faq_category_id": 5 }
  ],
  "idempotency_key": "uuid"
}
```

## Implementation Details

- Model callbacks (after_create_commit, after_update_commit, after_destroy_commit)
- Bulk operations skip individual callbacks and send one aggregated webhook
- FaqCategory deletion sends bulk webhook for all deleted FAQ items
- Webhooks sent asynchronously via WebhookJob