### PR TITLE
feat: account schedules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,4 @@ BASE-DE-DATOS.md
 *.md
 !docs/**/*.md
 /docs
+/db/local_dev_scripts

--- a/.gitignore
+++ b/.gitignore
@@ -124,4 +124,3 @@ BASE-DE-DATOS.md
 *.md
 !docs/**/*.md
 /docs
-/db/local_dev_scripts

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -50,6 +50,7 @@ class Api::V1::AccountsController < Api::BaseController
       @account.settings.merge!(settings_params)
       @account.custom_attributes['onboarding_step'] = 'invite_team' if @account.custom_attributes['onboarding_step'] == 'account_update'
       update_account_address if account_address_params.present? && administrator?
+      update_business_hours if business_hours_params.present? && administrator?
       @account.save!
     end
   end
@@ -96,7 +97,7 @@ class Api::V1::AccountsController < Api::BaseController
 
   def settings_params
     params.permit(:auto_resolve_after, :auto_resolve_message, :auto_resolve_ignore_waiting, :audio_transcriptions, :auto_resolve_label,
-                  conversation_required_attributes: [])
+                  :business_hours_enabled, :business_hours_timezone, conversation_required_attributes: [])
   end
 
   def account_address_params
@@ -113,6 +114,20 @@ class Api::V1::AccountsController < Api::BaseController
       address ? address.update!(address_attrs) : @account.account_addresses.create!(address_attrs)
     else
       @account.account_addresses.create!(address_attrs)
+    end
+  end
+
+  def business_hours_params
+    params.permit(business_hours: %i[day_of_week open_hour open_minutes close_hour close_minutes closed_all_day open_all_day])[:business_hours]
+  end
+
+  def update_business_hours
+    return unless business_hours_params.present?
+
+    business_hours_params.each do |day_hours|
+      wh = @account.business_working_hours.find_or_initialize_by(day_of_week: day_hours[:day_of_week])
+      wh.assign_attributes(day_hours.except(:day_of_week))
+      wh.save!
     end
   end
 

--- a/app/javascript/dashboard/i18n/locale/en/generalSettings.json
+++ b/app/javascript/dashboard/i18n/locale/en/generalSettings.json
@@ -122,6 +122,28 @@
         "INBOUND_EMAIL_ENABLED": "Conversation continuity with emails is enabled for your account.",
         "CUSTOM_EMAIL_DOMAIN_ENABLED": "You can receive emails in your custom domain now."
       },
+      "BUSINESS_HOURS": {
+        "TITLE": "Business hours",
+        "NOTE": "Configure your business working hours. This information helps AI agents provide accurate availability information to customers.",
+        "ENABLE": "Enable business hours",
+        "TIMEZONE": "Timezone",
+        "WEEKLY_SCHEDULE": "Weekly schedule",
+        "DAYS": {
+          "SUNDAY": "Sunday",
+          "MONDAY": "Monday",
+          "TUESDAY": "Tuesday",
+          "WEDNESDAY": "Wednesday",
+          "THURSDAY": "Thursday",
+          "FRIDAY": "Friday",
+          "SATURDAY": "Saturday"
+        },
+        "UPDATE_BUTTON": "Save business hours",
+        "ERROR": "Please fix the schedule errors before saving",
+        "API": {
+          "SUCCESS": "Business hours updated successfully",
+          "ERROR": "Failed to update business hours"
+        }
+      },
       "ACCOUNT_ADDRESS": {
         "TITLE": "Company address",
         "NOTE": "Configure the physical address information for your company. This information can be used in templates and communications.",

--- a/app/javascript/dashboard/i18n/locale/es/generalSettings.json
+++ b/app/javascript/dashboard/i18n/locale/es/generalSettings.json
@@ -122,6 +122,28 @@
         "INBOUND_EMAIL_ENABLED": "Continuidad de la conversación con emails está habilitada para su cuenta.",
         "CUSTOM_EMAIL_DOMAIN_ENABLED": "Ahora puede recibir emails en su dominio personalizado."
       },
+      "BUSINESS_HOURS": {
+        "TITLE": "Horario de atención",
+        "NOTE": "Configura el horario de atención de tu negocio. Esta información ayuda a los agentes de IA a proporcionar información precisa sobre disponibilidad a los clientes.",
+        "ENABLE": "Habilitar horario de atención",
+        "TIMEZONE": "Zona horaria",
+        "WEEKLY_SCHEDULE": "Horario semanal",
+        "DAYS": {
+          "SUNDAY": "Domingo",
+          "MONDAY": "Lunes",
+          "TUESDAY": "Martes",
+          "WEDNESDAY": "Miércoles",
+          "THURSDAY": "Jueves",
+          "FRIDAY": "Viernes",
+          "SATURDAY": "Sábado"
+        },
+        "UPDATE_BUTTON": "Guardar horario",
+        "ERROR": "Por favor corrige los errores en el horario antes de guardar",
+        "API": {
+          "SUCCESS": "Horario de atención actualizado correctamente",
+          "ERROR": "Error al actualizar el horario de atención"
+        }
+      },
       "ACCOUNT_ADDRESS": {
         "TITLE": "Dirección de la empresa",
         "NOTE": "Configura la información de dirección física de tu empresa. Esta información puede usarse en plantillas y comunicaciones.",

--- a/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
@@ -16,6 +16,7 @@ import BuildInfo from './components/BuildInfo.vue';
 import AccountDelete from './components/AccountDelete.vue';
 import AudioTranscription from './components/AudioTranscription.vue';
 import AccountAddress from './components/AccountAddress.vue';
+import AccountBusinessHours from './components/AccountBusinessHours.vue';
 import SectionLayout from './components/SectionLayout.vue';
 
 export default {
@@ -27,6 +28,7 @@ export default {
     AccountDelete,
     AudioTranscription,
     AccountAddress,
+    AccountBusinessHours,
     SectionLayout,
     WithLabel,
     NextInput,
@@ -245,6 +247,7 @@ export default {
     </div>
     <AudioTranscription v-if="showAudioTranscriptionConfig" />
     <AccountAddress v-if="isAdministrator" />
+    <AccountBusinessHours v-if="isAdministrator" />
     <AccountId />
     <div v-if="!uiFlags.isFetchingItem && isOnChatwootCloud">
       <AccountDelete />

--- a/app/javascript/dashboard/routes/dashboard/settings/account/components/AccountBusinessHours.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/components/AccountBusinessHours.vue
@@ -1,0 +1,267 @@
+<script setup>
+import { ref, watch, computed, onMounted, onUnmounted } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useStore } from 'vuex';
+import { useAccount } from 'dashboard/composables/useAccount';
+import { useAlert } from 'dashboard/composables';
+import AccountAPI from 'dashboard/api/account';
+import WithLabel from 'v3/components/Form/WithLabel.vue';
+import NextButton from 'dashboard/components-next/button/Button.vue';
+import BusinessDay from '../../inbox/components/BusinessDay.vue';
+import {
+  timeSlotParse,
+  timeSlotTransform,
+  defaultTimeSlot,
+  dynamicTimeZoneOptions,
+} from '../../inbox/helpers/businessHour';
+
+const DEFAULT_TIMEZONE = {
+  label: 'Pacific Time (US & Canada) (GMT-07:00)',
+  value: 'America/Los_Angeles',
+};
+
+const { t, locale } = useI18n();
+const store = useStore();
+const { currentAccount } = useAccount();
+
+const isExpanded = ref(false);
+const isSubmitting = ref(false);
+const businessHoursEnabled = ref(false);
+const timezone = ref(DEFAULT_TIMEZONE);
+const timeSlots = ref([...defaultTimeSlot]);
+const currentTime = ref(new Date());
+let clockInterval = null;
+
+const formattedDateTime = computed(() => {
+  if (!timezone.value?.value) return '';
+
+  const dateFormatter = new Intl.DateTimeFormat(locale.value, {
+    timeZone: timezone.value.value,
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  const timeFormatter = new Intl.DateTimeFormat(locale.value, {
+    timeZone: timezone.value.value,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: true,
+  });
+
+  return {
+    date: dateFormatter.format(currentTime.value),
+    time: timeFormatter.format(currentTime.value),
+  };
+});
+
+const startClock = () => {
+  clockInterval = setInterval(() => {
+    currentTime.value = new Date();
+  }, 1000);
+};
+
+const stopClock = () => {
+  if (clockInterval) {
+    clearInterval(clockInterval);
+    clockInterval = null;
+  }
+};
+
+onMounted(() => {
+  startClock();
+});
+
+onUnmounted(() => {
+  stopClock();
+});
+
+const dayNames = {
+  0: 'SUNDAY',
+  1: 'MONDAY',
+  2: 'TUESDAY',
+  3: 'WEDNESDAY',
+  4: 'THURSDAY',
+  5: 'FRIDAY',
+  6: 'SATURDAY',
+};
+
+const timeZones = computed(() => [...dynamicTimeZoneOptions()]);
+
+const hasError = computed(() => {
+  if (!businessHoursEnabled.value) return false;
+  return timeSlots.value.filter(slot => slot.from && !slot.valid).length > 0;
+});
+
+const toggleExpanded = () => {
+  isExpanded.value = !isExpanded.value;
+};
+
+const onSlotUpdate = (slotIndex, slotData) => {
+  timeSlots.value = timeSlots.value.map(item =>
+    item.day === slotIndex ? slotData : item
+  );
+};
+
+watch(
+  currentAccount,
+  () => {
+    const account = currentAccount.value;
+    if (account) {
+      businessHoursEnabled.value = account.business_hours_enabled || false;
+
+      const savedTimezone = account.business_hours_timezone;
+      timezone.value =
+        timeZones.value.find(item => savedTimezone === item.value) ||
+        DEFAULT_TIMEZONE;
+
+      const businessHours = account.business_hours || [];
+      const slots = timeSlotParse(businessHours).length
+        ? timeSlotParse(businessHours)
+        : [...defaultTimeSlot];
+      timeSlots.value = slots.sort((a, b) => a.day - b.day);
+    }
+  },
+  { deep: true, immediate: true }
+);
+
+const handleSubmit = async () => {
+  if (hasError.value) {
+    useAlert(t('GENERAL_SETTINGS.FORM.BUSINESS_HOURS.ERROR'));
+    return;
+  }
+
+  try {
+    isSubmitting.value = true;
+    const payload = {
+      business_hours_enabled: businessHoursEnabled.value,
+      business_hours_timezone: timezone.value.value,
+      business_hours: timeSlotTransform(timeSlots.value),
+    };
+    const response = await AccountAPI.update('', payload);
+    store.commit('accounts/EDIT_ACCOUNT', response.data);
+    useAlert(t('GENERAL_SETTINGS.FORM.BUSINESS_HOURS.API.SUCCESS'));
+  } catch (error) {
+    useAlert(
+      error?.response?.data?.message ||
+        t('GENERAL_SETTINGS.FORM.BUSINESS_HOURS.API.ERROR')
+    );
+  } finally {
+    isSubmitting.value = false;
+  }
+};
+</script>
+
+<template>
+  <div class="grid grid-cols-1 pt-8 gap-5 border-t border-n-weak pb-8">
+    <button
+      type="button"
+      class="w-full flex items-center justify-between text-left cursor-pointer group"
+      @click="toggleExpanded"
+    >
+      <div class="flex-1">
+        <h4 class="text-lg font-medium text-n-slate-12">
+          {{ t('GENERAL_SETTINGS.FORM.BUSINESS_HOURS.TITLE') }}
+        </h4>
+        <p class="text-n-slate-11 text-sm mt-2">
+          {{ t('GENERAL_SETTINGS.FORM.BUSINESS_HOURS.NOTE') }}
+        </p>
+      </div>
+      <fluent-icon
+        icon="chevron-down"
+        size="20"
+        class="ml-4 text-n-slate-11 transition-transform duration-200"
+        :class="{ 'rotate-180': isExpanded }"
+      />
+    </button>
+
+    <transition
+      enter-active-class="transition-all duration-200 ease-out"
+      leave-active-class="transition-all duration-200 ease-in"
+      enter-from-class="opacity-0 max-h-0"
+      enter-to-class="opacity-100 max-h-[2000px]"
+      leave-from-class="opacity-100 max-h-[2000px]"
+      leave-to-class="opacity-0 max-h-0"
+    >
+      <form
+        v-show="isExpanded"
+        class="grid gap-4 mt-4 overflow-hidden"
+        @submit.prevent="handleSubmit"
+      >
+        <label for="toggle-business-hours" class="flex items-center gap-2">
+          <input
+            id="toggle-business-hours"
+            v-model="businessHoursEnabled"
+            type="checkbox"
+            name="toggle-business-hours"
+          />
+          <span class="text-sm font-medium text-n-slate-12">
+            {{ t('GENERAL_SETTINGS.FORM.BUSINESS_HOURS.ENABLE') }}
+          </span>
+        </label>
+
+        <div v-if="businessHoursEnabled" class="space-y-4">
+          <WithLabel :label="t('GENERAL_SETTINGS.FORM.BUSINESS_HOURS.TIMEZONE')">
+            <div class="flex items-center gap-4 mt-2">
+              <multiselect
+                v-model="timezone"
+                :options="timeZones"
+                deselect-label=""
+                select-label=""
+                selected-label=""
+                track-by="value"
+                label="label"
+                close-on-select
+                :placeholder="t('INBOX_MGMT.BUSINESS_HOURS.DAY.CHOOSE')"
+                :allow-empty="false"
+                class="flex-1"
+              />
+              <div
+                v-if="timezone?.value"
+                class="px-3 py-2 bg-n-alpha-black2 dark:bg-n-solid-1 rounded-md border border-n-weak inline-flex items-center gap-3 shrink-0"
+              >
+                <span class="text-base font-mono font-medium text-n-slate-12">
+                  {{ formattedDateTime.time }}
+                </span>
+                <span class="text-xs text-n-slate-11 capitalize">
+                  {{ formattedDateTime.date }}
+                </span>
+              </div>
+            </div>
+          </WithLabel>
+
+          <div>
+            <label class="text-sm font-medium text-n-slate-12 mb-2 block">
+              {{ t('GENERAL_SETTINGS.FORM.BUSINESS_HOURS.WEEKLY_SCHEDULE') }}
+            </label>
+            <BusinessDay
+              v-for="timeSlot in timeSlots"
+              :key="timeSlot.day"
+              :day-name="t(`GENERAL_SETTINGS.FORM.BUSINESS_HOURS.DAYS.${dayNames[timeSlot.day]}`)"
+              :time-slot="timeSlot"
+              @update="data => onSlotUpdate(timeSlot.day, data)"
+            />
+          </div>
+        </div>
+
+        <div class="flex gap-2">
+          <NextButton
+            blue
+            type="submit"
+            :is-loading="isSubmitting"
+            :disabled="hasError"
+            :label="t('GENERAL_SETTINGS.FORM.BUSINESS_HOURS.UPDATE_BUTTON')"
+          />
+        </div>
+      </form>
+    </transition>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+::v-deep .multiselect {
+  @apply m-0;
+}
+</style>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/helpers/businessHour.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/helpers/businessHour.js
@@ -141,9 +141,75 @@ export const timeSlotTransform = timeSlots => {
   });
 };
 
+const getTimezoneOffset = tz => {
+  try {
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      timeZoneName: 'shortOffset',
+    });
+    const parts = formatter.formatToParts(new Date());
+    const offsetPart = parts.find(part => part.type === 'timeZoneName');
+    return offsetPart ? offsetPart.value : '';
+  } catch {
+    return '';
+  }
+};
+
+const getTimezoneOffsetMinutes = tz => {
+  try {
+    const now = new Date();
+    const utcDate = new Date(now.toLocaleString('en-US', { timeZone: 'UTC' }));
+    const tzDate = new Date(now.toLocaleString('en-US', { timeZone: tz }));
+    return (tzDate - utcDate) / 60000;
+  } catch {
+    return 0;
+  }
+};
+
+const getTimezoneLongName = (tz, locale) => {
+  try {
+    const formatter = new Intl.DateTimeFormat(locale, {
+      timeZone: tz,
+      timeZoneName: 'long',
+    });
+    const parts = formatter.formatToParts(new Date());
+    const namePart = parts.find(part => part.type === 'timeZoneName');
+    return namePart ? namePart.value : tz;
+  } catch {
+    return tz;
+  }
+};
+
+const formatTimezoneName = tz => {
+  // Convert "America/Mexico_City" to "Mexico City"
+  const city = tz.split('/').pop().replace(/_/g, ' ');
+  return city;
+};
+
+// Original function using static timezones.json (for backwards compatibility)
 export const timeZoneOptions = () => {
   return Object.keys(timeZoneData).map(key => ({
     label: key,
     value: timeZoneData[key],
   }));
+};
+
+// Dynamic IANA timezone options with real-time offsets
+export const dynamicTimeZoneOptions = () => {
+  const timeZones = Intl.supportedValuesOf('timeZone');
+
+  const options = timeZones.map(tz => {
+    const offset = getTimezoneOffset(tz);
+    const city = formatTimezoneName(tz);
+    return {
+      label: `${city} (${offset})`,
+      value: tz,
+      offsetMinutes: getTimezoneOffsetMinutes(tz),
+    };
+  });
+
+  // Sort by offset (west to east)
+  options.sort((a, b) => a.offsetMinutes - b.offsetMinutes);
+
+  return options.map(({ label, value }) => ({ label, value }));
 };

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -137,8 +137,7 @@ class Account < ApplicationRecord
   has_many :webhooks, dependent: :destroy_async
   has_many :whatsapp_channels, dependent: :destroy_async, class_name: '::Channel::Whatsapp'
   has_many :working_hours, dependent: :destroy_async
-  has_many :business_working_hours, -> { where(workable_type: 'Account') },
-           class_name: 'WorkingHour', as: :workable, dependent: :destroy_async
+  has_many :business_working_hours, class_name: 'WorkingHour', as: :workable, dependent: :destroy_async
   has_many :marketing_campaigns, dependent: :destroy_async
   has_many :pipeline_statuses, dependent: :destroy_async
   has_many :product_catalogs, dependent: :destroy_async

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -87,6 +87,7 @@ class Account < ApplicationRecord
 
   store_accessor :settings, :audio_transcriptions, :auto_resolve_label
   store_accessor :settings, :captain_models, :captain_features
+  store_accessor :settings, :business_hours_enabled, :business_hours_timezone
 
   has_many :account_users, dependent: :destroy_async
   has_many :agent_bot_inboxes, dependent: :destroy_async
@@ -136,6 +137,8 @@ class Account < ApplicationRecord
   has_many :webhooks, dependent: :destroy_async
   has_many :whatsapp_channels, dependent: :destroy_async, class_name: '::Channel::Whatsapp'
   has_many :working_hours, dependent: :destroy_async
+  has_many :business_working_hours, -> { where(workable_type: 'Account') },
+           class_name: 'WorkingHour', as: :workable, dependent: :destroy_async
   has_many :marketing_campaigns, dependent: :destroy_async
   has_many :pipeline_statuses, dependent: :destroy_async
   has_many :product_catalogs, dependent: :destroy_async
@@ -212,6 +215,31 @@ class Account < ApplicationRecord
     return nil unless feature_enabled?(:whatsapp_groups)
 
     @whatsapp_groups_inbox ||= Whatsapp::GroupsInboxService.new(account: self).find_or_create_groups_inbox
+  end
+
+  def business_hours_open?
+    return true unless business_hours_enabled
+
+    tz = business_hours_timezone || 'UTC'
+    current_time = Time.current.in_time_zone(tz)
+    today_hours = business_working_hours.find_by(day_of_week: current_time.wday)
+    return true unless today_hours
+
+    today_hours.open_now?
+  end
+
+  def business_hours_schedule
+    business_working_hours.order(:day_of_week).map do |wh|
+      {
+        day_of_week: wh.day_of_week,
+        open_hour: wh.open_hour,
+        open_minutes: wh.open_minutes,
+        close_hour: wh.close_hour,
+        close_minutes: wh.close_minutes,
+        closed_all_day: wh.closed_all_day,
+        open_all_day: wh.open_all_day
+      }
+    end
   end
 
   private

--- a/app/models/working_hour.rb
+++ b/app/models/working_hour.rb
@@ -30,7 +30,7 @@ class WorkingHour < ApplicationRecord
   before_validation :ensure_open_all_day_hours
   before_save :assign_account
 
-  validates :workable_type, presence: true, inclusion: { in: %w[Inbox AccountUser] }
+  validates :workable_type, presence: true, inclusion: { in: %w[Inbox AccountUser Account] }
   validates :workable_id,   presence: true
 
   validates :open_hour,     presence: true, unless: :closed_all_day?
@@ -56,15 +56,16 @@ class WorkingHour < ApplicationRecord
   def open_at?(time)
     return false if closed_all_day?
 
-    open_time = Time.zone.now.in_time_zone(workable.timezone).change({ hour: open_hour, min: open_minutes })
-    close_time = Time.zone.now.in_time_zone(workable.timezone).change({ hour: close_hour, min: close_minutes })
+    tz = workable_timezone
+    open_time = Time.zone.now.in_time_zone(tz).change({ hour: open_hour, min: open_minutes })
+    close_time = Time.zone.now.in_time_zone(tz).change({ hour: close_hour, min: close_minutes })
 
     time.between?(open_time, close_time)
   end
 
   def open_now?
-    inbox_time = Time.zone.now.in_time_zone(workable.timezone)
-    open_at?(inbox_time)
+    current_time = Time.zone.now.in_time_zone(workable_timezone)
+    open_at?(current_time)
   end
 
   def closed_now?
@@ -73,8 +74,16 @@ class WorkingHour < ApplicationRecord
 
   private
 
+  def workable_timezone
+    if workable.is_a?(Account)
+      workable.business_hours_timezone || 'UTC'
+    else
+      workable.timezone
+    end
+  end
+
   def assign_account
-    self.account_id = workable.account_id
+    self.account_id = workable.is_a?(Account) ? workable.id : workable.account_id
   end
 
   def close_after_open

--- a/app/views/api/v1/models/_account.json.jbuilder
+++ b/app/views/api/v1/models/_account.json.jbuilder
@@ -27,6 +27,10 @@ json.status @account.status
 json.pinecone_index @account.pinecone_index
 json.cache_keys @account.cache_keys
 
+json.business_hours_enabled resource.business_hours_enabled
+json.business_hours_timezone resource.business_hours_timezone
+json.business_hours resource.business_hours_schedule
+
 if @account.account_addresses.any?
   json.account_address do
     address = @account.account_addresses.first

--- a/enterprise/app/services/captain/copilot/chat_service.rb
+++ b/enterprise/app/services/captain/copilot/chat_service.rb
@@ -70,6 +70,7 @@ class Captain::Copilot::ChatService < Llm::BaseAiService
     tools << Captain::Tools::Copilot::SearchArticlesService.new(@assistant, user: @user)
     tools << Captain::Tools::Copilot::SearchContactsService.new(@assistant, user: @user)
     tools << Captain::Tools::Copilot::SearchLinearIssuesService.new(@assistant, user: @user)
+    tools << Captain::Tools::BusinessHoursLookupTool.new(@assistant)
 
     tools.select(&:active?)
   end

--- a/enterprise/app/services/captain/llm/assistant_chat_service.rb
+++ b/enterprise/app/services/captain/llm/assistant_chat_service.rb
@@ -28,7 +28,10 @@ class Captain::Llm::AssistantChatService < Llm::BaseAiService
   private
 
   def build_tools
-    [Captain::Tools::SearchDocumentationService.new(@assistant, user: nil)]
+    [
+      Captain::Tools::SearchDocumentationService.new(@assistant, user: nil),
+      Captain::Tools::BusinessHoursLookupTool.new(@assistant)
+    ]
   end
 
   def system_message

--- a/enterprise/lib/captain/tools/business_hours_lookup_tool.rb
+++ b/enterprise/lib/captain/tools/business_hours_lookup_tool.rb
@@ -1,0 +1,72 @@
+class Captain::Tools::BusinessHoursLookupTool < Captain::Tools::BasePublicTool
+  description 'Get business working hours and current open/closed status for the account'
+
+  def perform(_tool_context)
+    log_tool_usage('fetching_business_hours')
+
+    account = Account.find(@assistant.account_id)
+
+    unless account.business_hours_enabled
+      log_tool_usage('business_hours_not_configured')
+      return 'Business hours are not configured for this account.'
+    end
+
+    format_business_hours(account)
+  end
+
+  private
+
+  def format_business_hours(account)
+    timezone = account.business_hours_timezone || 'UTC'
+    current_time = Time.current.in_time_zone(timezone)
+    is_open = account.business_hours_open?
+    schedule = account.business_hours_schedule
+
+    log_tool_usage('business_hours_found', {
+      timezone: timezone,
+      is_open: is_open,
+      schedule_days: schedule.size
+    })
+
+    result = []
+    result << "Business Hours Information"
+    result << "=========================="
+    result << ""
+    result << "Timezone: #{timezone}"
+    result << "Current Time: #{current_time.strftime('%A, %B %d, %Y at %I:%M %p')}"
+    result << "Status: #{is_open ? 'OPEN' : 'CLOSED'}"
+    result << ""
+    result << "Weekly Schedule:"
+    result << format_schedule(schedule)
+
+    result.join("\n")
+  end
+
+  def format_schedule(schedule)
+    day_names = %w[Sunday Monday Tuesday Wednesday Thursday Friday Saturday]
+
+    schedule.map do |day|
+      day_name = day_names[day[:day_of_week]]
+      hours = format_day_hours(day)
+      "  #{day_name}: #{hours}"
+    end.join("\n")
+  end
+
+  def format_day_hours(day)
+    return 'Closed' if day[:closed_all_day]
+    return 'Open 24 hours' if day[:open_all_day]
+
+    open_time = format_time(day[:open_hour], day[:open_minutes])
+    close_time = format_time(day[:close_hour], day[:close_minutes])
+
+    "#{open_time} - #{close_time}"
+  end
+
+  def format_time(hour, minutes)
+    return 'N/A' if hour.nil?
+
+    period = hour >= 12 ? 'PM' : 'AM'
+    display_hour = hour > 12 ? hour - 12 : (hour == 0 ? 12 : hour)
+    format('%d:%02d %s', display_hour, minutes || 0, period)
+  end
+end


### PR DESCRIPTION
## Description

- Add business hours settings to Account model (enabled, timezone)
- Create AccountBusinessHours.vue component with timezone selector and live clock
- Extend WorkingHour model to support Account as workable type
- Add BusinessHoursLookupTool for Captain AI to check business hours
- Update accounts controller and API to handle business hours CRUD
- Add i18n translations (EN/ES) for business hours UI
- Add dynamicTimeZoneOptions helper for IANA timezone selection