### PR TITLE
fix: product catalog webhoks

### DIFF
--- a/app/controllers/api/v1/accounts/product_catalogs_controller.rb
+++ b/app/controllers/api/v1/accounts/product_catalogs_controller.rb
@@ -431,6 +431,7 @@ class Api::V1::Accounts::ProductCatalogsController < Api::V1::Accounts::BaseCont
   end
 
   def dispatch_bulk_delete_event(deleted_product_ids, deleted_count)
+    Current.account.increment_product_catalog_version!
     Rails.configuration.dispatcher.dispatch(
       PRODUCT_CATALOG_UPDATED,
       Time.zone.now,

--- a/app/javascript/dashboard/components-next/KnowledgeBase/Pages/ProductCatalogPage/ProcessingStatus.vue
+++ b/app/javascript/dashboard/components-next/KnowledgeBase/Pages/ProductCatalogPage/ProcessingStatus.vue
@@ -9,6 +9,7 @@
           :class="{
             'i-lucide-loader-circle animate-spin text-n-blue-11': statusUpper === 'PROCESSING',
             'i-lucide-check-circle text-n-green-11': statusUpper === 'COMPLETED',
+            'i-lucide-alert-triangle text-n-orange-11': statusUpper === 'COMPLETED_WITH_WARNINGS',
             'i-lucide-x-circle text-n-red-11': statusUpper === 'FAILED',
             'i-lucide-clock text-n-orange-11': statusUpper === 'PENDING',
             'i-lucide-ban text-n-slate-11': statusUpper === 'CANCELLED'
@@ -26,7 +27,7 @@
           <i class="i-lucide-x w-5 h-5" />
         </button>
         <button
-          v-else-if="['COMPLETED', 'FAILED', 'PARTIALLY_COMPLETED', 'CANCELLED'].includes(statusUpper)"
+          v-else-if="['COMPLETED', 'COMPLETED_WITH_WARNINGS', 'FAILED', 'PARTIALLY_COMPLETED', 'CANCELLED'].includes(statusUpper)"
           class="flex-shrink-0 p-2 text-n-slate-11 hover:text-n-slate-12 hover:bg-n-slate-3 rounded-lg transition-colors"
           @click="$emit('close')"
         >
@@ -49,6 +50,7 @@
             :class="{
               'bg-n-blue-9': statusUpper === 'PROCESSING' || statusUpper === 'PENDING',
               'bg-n-green-9': statusUpper === 'COMPLETED',
+              'bg-n-orange-9': statusUpper === 'COMPLETED_WITH_WARNINGS',
               'bg-n-red-9': statusUpper === 'FAILED',
               'bg-n-slate-9': statusUpper === 'CANCELLED'
             }"
@@ -117,6 +119,7 @@
           :class="{
             'i-lucide-loader-circle animate-spin text-n-blue-11': statusUpper === 'PROCESSING',
             'i-lucide-check-circle text-n-green-11': statusUpper === 'COMPLETED',
+            'i-lucide-alert-triangle text-n-orange-11': statusUpper === 'COMPLETED_WITH_WARNINGS',
             'i-lucide-x-circle text-n-red-11': statusUpper === 'FAILED',
             'i-lucide-clock text-n-orange-11': statusUpper === 'PENDING',
             'i-lucide-ban text-n-slate-11': statusUpper === 'CANCELLED'
@@ -136,7 +139,7 @@
             </span>
             <!-- Close button for completed/failed/cancelled statuses -->
             <button
-              v-if="['COMPLETED', 'FAILED', 'PARTIALLY_COMPLETED', 'CANCELLED'].includes(statusUpper)"
+              v-if="['COMPLETED', 'COMPLETED_WITH_WARNINGS', 'FAILED', 'PARTIALLY_COMPLETED', 'CANCELLED'].includes(statusUpper)"
               class="text-n-slate-11 hover:text-n-slate-12 transition-colors"
               @click="$emit('close')"
             >
@@ -161,6 +164,7 @@
               :class="{
                 'bg-n-blue-9': statusUpper === 'PROCESSING' || statusUpper === 'PENDING',
                 'bg-n-green-9': statusUpper === 'COMPLETED',
+                'bg-n-orange-9': statusUpper === 'COMPLETED_WITH_WARNINGS',
                 'bg-n-red-9': statusUpper === 'FAILED',
                 'bg-n-slate-9': statusUpper === 'CANCELLED'
               }"
@@ -246,7 +250,7 @@ const props = defineProps({
   status: {
     type: String,
     required: true,
-    validator: value => ['PENDING', 'PROCESSING', 'COMPLETED', 'FAILED', 'PARTIALLY_COMPLETED', 'CANCELLED', 'pending', 'processing', 'completed', 'failed', 'partially_completed', 'cancelled'].includes(value)
+    validator: value => ['PENDING', 'PROCESSING', 'COMPLETED', 'COMPLETED_WITH_WARNINGS', 'FAILED', 'PARTIALLY_COMPLETED', 'CANCELLED', 'pending', 'processing', 'completed', 'completed_with_warnings', 'failed', 'partially_completed', 'cancelled'].includes(value)
   },
   fileName: {
     type: String,
@@ -320,6 +324,8 @@ const statusMessage = computed(() => {
       return isExport
         ? t('KNOWLEDGE_BASE.PRODUCT_CATALOG.EXPORT_ALL.SUCCESS_MESSAGE')
         : t('KNOWLEDGE_BASE.PRODUCT_CATALOG.UPLOAD.SUCCESS_MESSAGE');
+    case 'COMPLETED_WITH_WARNINGS':
+      return props.errorMessage || t('KNOWLEDGE_BASE.PRODUCT_CATALOG.UPLOAD.SUCCESS_MESSAGE');
     case 'PARTIALLY_COMPLETED':
       return `${props.processedRecords} of ${props.totalRecords} records processed successfully`;
     case 'FAILED':
@@ -340,7 +346,7 @@ const showProgress = computed(() => {
 });
 
 const showStats = computed(() => {
-  return props.totalRecords > 0 && ['PROCESSING', 'COMPLETED', 'PARTIALLY_COMPLETED', 'FAILED'].includes(statusUpper.value);
+  return props.totalRecords > 0 && ['PROCESSING', 'COMPLETED', 'COMPLETED_WITH_WARNINGS', 'PARTIALLY_COMPLETED', 'FAILED'].includes(statusUpper.value);
 });
 
 const canCancel = computed(() => {
@@ -349,7 +355,7 @@ const canCancel = computed(() => {
 
 // Check if there are errors (for showing success message or not)
 const hasErrors = computed(() => {
-  if (!['FAILED', 'PARTIALLY_COMPLETED'].includes(statusUpper.value)) {
+  if (!['FAILED', 'PARTIALLY_COMPLETED', 'COMPLETED_WITH_WARNINGS'].includes(statusUpper.value)) {
     return false;
   }
   return props.failedRecords > 0 || !!props.errorMessage;
@@ -357,7 +363,7 @@ const hasErrors = computed(() => {
 
 // Check if there are downloadable error details (for showing download button)
 const hasDownloadableErrors = computed(() => {
-  if (!['FAILED', 'PARTIALLY_COMPLETED'].includes(statusUpper.value)) {
+  if (!['FAILED', 'PARTIALLY_COMPLETED', 'COMPLETED_WITH_WARNINGS'].includes(statusUpper.value)) {
     return false;
   }
 

--- a/app/javascript/dashboard/i18n/locale/en/knowledgeBase.json
+++ b/app/javascript/dashboard/i18n/locale/en/knowledgeBase.json
@@ -203,6 +203,7 @@
         "PENDING": "Pending",
         "PROCESSING": "Processing",
         "COMPLETED": "Completed",
+        "COMPLETED_WITH_WARNINGS": "Completed with Warnings",
         "FAILED": "Failed",
         "PARTIALLY_COMPLETED": "Partially Completed",
         "CANCELLED": "Cancelled"

--- a/app/javascript/dashboard/i18n/locale/es/knowledgeBase.json
+++ b/app/javascript/dashboard/i18n/locale/es/knowledgeBase.json
@@ -203,6 +203,7 @@
         "PENDING": "Pendiente",
         "PROCESSING": "Procesando",
         "COMPLETED": "Completado",
+        "COMPLETED_WITH_WARNINGS": "Completado con Advertencias",
         "FAILED": "Fallido",
         "PARTIALLY_COMPLETED": "Parcialmente Completado",
         "CANCELLED": "Cancelado"

--- a/app/javascript/dashboard/routes/dashboard/knowledge-base/pages/ProductCatalogPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/knowledge-base/pages/ProductCatalogPage.vue
@@ -487,7 +487,7 @@ const checkActiveProcessing = async () => {
     active = bulkRequests.find(req => {
       const createdAt = new Date(req.created_at);
       return req.entity_type === 'ProductCatalog' &&
-        ['COMPLETED', 'FAILED', 'PARTIALLY_COMPLETED', 'CANCELLED'].includes(req.status?.toUpperCase()) &&
+        ['COMPLETED', 'COMPLETED_WITH_WARNINGS', 'FAILED', 'PARTIALLY_COMPLETED', 'CANCELLED'].includes(req.status?.toUpperCase()) &&
         !req.dismissed_at &&
         createdAt > twentyFourHoursAgo;
     });
@@ -528,7 +528,7 @@ const startPolling = () => {
       }
 
       // Stop polling if completed or failed
-      if (['COMPLETED', 'FAILED', 'PARTIALLY_COMPLETED'].includes(statusUpper)) {
+      if (['COMPLETED', 'COMPLETED_WITH_WARNINGS', 'FAILED', 'PARTIALLY_COMPLETED'].includes(statusUpper)) {
         // Always refresh product list at the end FIRST, regardless of status
         await store.dispatch('productCatalogs/get', { page: meta.value.current_page, per_page: 50 });
 
@@ -556,8 +556,8 @@ const startPolling = () => {
         } else if (statusUpper === 'FAILED') {
           useAlert(updated.error_message || t('KNOWLEDGE_BASE.PRODUCT_CATALOG.UPLOAD.ERROR'));
           // Keep activeProcessing so user can download errors
-        } else if (statusUpper === 'PARTIALLY_COMPLETED') {
-          // Keep activeProcessing so user can download errors
+        } else if (statusUpper === 'PARTIALLY_COMPLETED' || statusUpper === 'COMPLETED_WITH_WARNINGS') {
+          // Keep activeProcessing so user can download errors/warnings
         }
       }
     }
@@ -674,7 +674,7 @@ const handleCloseProcessingStatus = async () => {
   // Only allow closing if status is final (not PENDING or PROCESSING)
   if (activeProcessing.value) {
     const statusUpper = activeProcessing.value.status?.toUpperCase();
-    if (['COMPLETED', 'FAILED', 'PARTIALLY_COMPLETED', 'CANCELLED'].includes(statusUpper)) {
+    if (['COMPLETED', 'COMPLETED_WITH_WARNINGS', 'FAILED', 'PARTIALLY_COMPLETED', 'CANCELLED'].includes(statusUpper)) {
       const requestId = activeProcessing.value.id;
 
       // Refresh products first to show latest data

--- a/app/javascript/dashboard/routes/dashboard/knowledge-base/pages/UploadHistoryPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/knowledge-base/pages/UploadHistoryPage.vue
@@ -364,6 +364,8 @@ const getStatusClass = (status) => {
   switch (statusUpper) {
     case 'COMPLETED':
       return 'bg-n-green-2 text-n-green-11 border border-n-green-6';
+    case 'COMPLETED_WITH_WARNINGS':
+      return 'bg-n-orange-2 text-n-orange-11 border border-n-orange-6';
     case 'FAILED':
       return 'bg-n-red-2 text-n-red-11 border border-n-red-6';
     case 'PROCESSING':
@@ -384,6 +386,8 @@ const getStatusIcon = (status) => {
   switch (statusUpper) {
     case 'COMPLETED':
       return 'i-lucide-check-circle';
+    case 'COMPLETED_WITH_WARNINGS':
+      return 'i-lucide-alert-triangle';
     case 'FAILED':
       return 'i-lucide-x-circle';
     case 'PROCESSING':
@@ -412,7 +416,7 @@ const formatDate = (dateString) => {
 
 const hasErrors = (request) => {
   const statusUpper = request.status?.toUpperCase();
-  if (!['FAILED', 'PARTIALLY_COMPLETED'].includes(statusUpper)) {
+  if (!['FAILED', 'PARTIALLY_COMPLETED', 'COMPLETED_WITH_WARNINGS'].includes(statusUpper)) {
     return false;
   }
 

--- a/app/jobs/product_catalogs/process_bulk_upload_job.rb
+++ b/app/jobs/product_catalogs/process_bulk_upload_job.rb
@@ -434,20 +434,30 @@ class ProductCatalogs::ProcessBulkUploadJob < ApplicationJob
   end
 
   def update_final_status(excel_result, media_result)
-    if excel_result[:success] && media_result[:success]
-      handle_successful_processing
+    if excel_result[:success]
+      # Excel was successful - always dispatch webhook even if media failed
+      # Products were created successfully, media errors are just warnings
+      handle_successful_processing(media_result)
     else
+      # Excel processing failed - no products were created
       handle_failed_processing(excel_result, media_result)
     end
   end
 
-  def handle_successful_processing
+  def handle_successful_processing(media_result)
     added_product_ids, updated_product_ids = categorize_processed_products
 
+    has_media_errors = !media_result[:success]
+
     if @bulk_request.failed_records.zero? && @bulk_request.processed_records.positive?
-      complete_bulk_request(added_product_ids, updated_product_ids)
+      if has_media_errors
+        # Products created successfully but some media URLs failed
+        complete_with_media_warnings(added_product_ids, updated_product_ids, media_result[:error])
+      else
+        complete_bulk_request(added_product_ids, updated_product_ids)
+      end
     elsif @bulk_request.failed_records.positive? && @bulk_request.processed_records.positive?
-      partially_complete_bulk_request(added_product_ids, updated_product_ids)
+      partially_complete_bulk_request(added_product_ids, updated_product_ids, media_result[:error])
     else
       fail_bulk_request('No records were processed successfully')
     end
@@ -481,11 +491,30 @@ class ProductCatalogs::ProcessBulkUploadJob < ApplicationJob
     )
   end
 
-  def partially_complete_bulk_request(added_product_ids, updated_product_ids)
+  def complete_with_media_warnings(added_product_ids, updated_product_ids, media_error)
+    @bulk_request.update!(
+      status: 'COMPLETED_WITH_WARNINGS',
+      progress: 100.0,
+      error_message: "Products created successfully. Media warnings: #{media_error}"
+    )
+    dispatch_catalog_updated_event(
+      added_count: added_product_ids.size,
+      updated_count: updated_product_ids.size,
+      deleted_count: 0,
+      added_product_ids: added_product_ids,
+      updated_product_ids: updated_product_ids,
+      deleted_product_ids: []
+    )
+  end
+
+  def partially_complete_bulk_request(added_product_ids, updated_product_ids, media_error = nil)
+    error_parts = ["Processed #{@bulk_request.processed_records} of #{@bulk_request.total_records} records. #{@bulk_request.failed_records} failed."]
+    error_parts << "Media: #{media_error}" if media_error.present?
+
     @bulk_request.update!(
       status: 'PARTIALLY_COMPLETED',
       progress: 100.0,
-      error_message: "Processed #{@bulk_request.processed_records} of #{@bulk_request.total_records} records. #{@bulk_request.failed_records} failed."
+      error_message: error_parts.join(' ')
     )
     dispatch_catalog_updated_event(
       added_count: added_product_ids.size,
@@ -510,6 +539,7 @@ class ProductCatalogs::ProcessBulkUploadJob < ApplicationJob
   end
 
   def dispatch_catalog_updated_event(added_count:, updated_count:, deleted_count:, added_product_ids:, updated_product_ids:, deleted_product_ids:)
+    @account.increment_product_catalog_version!
     Rails.configuration.dispatcher.dispatch(
       PRODUCT_CATALOG_UPDATED,
       Time.zone.now,

--- a/app/listeners/webhook_listener.rb
+++ b/app/listeners/webhook_listener.rb
@@ -144,17 +144,23 @@ class WebhookListener < BaseListener
     updated_product_ids = event.data[:updated_product_ids] || []
     deleted_product_ids = event.data[:deleted_product_ids] || []
 
+    total_changes = added_count + updated_count + deleted_count
+    full_sync_required = total_changes >= account.product_catalog_full_sync_threshold
+
     idempotency_key = SecureRandom.uuid
     payload = {
       event: __method__.to_s,
       timestamp: Time.zone.now.iso8601,
       account: account.webhook_data,
+      catalog_version: account.product_catalog_version,
+      full_sync_required: full_sync_required,
+      total_changes: total_changes,
       added_count: added_count,
       updated_count: updated_count,
       deleted_count: deleted_count,
-      added_product_ids: added_product_ids,
-      updated_product_ids: updated_product_ids,
-      deleted_product_ids: deleted_product_ids,
+      added_product_ids: full_sync_required ? [] : added_product_ids,
+      updated_product_ids: full_sync_required ? [] : updated_product_ids,
+      deleted_product_ids: full_sync_required ? [] : deleted_product_ids,
       idempotency_key: idempotency_key
     }
     deliver_account_webhooks(payload, account, idempotency_key)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -29,6 +29,8 @@ class Account < ApplicationRecord
   include Featurable
   include CacheKeys
   include CaptainFeaturable
+  
+  PRODUCT_CATALOG_FULL_SYNC_THRESHOLD = 500
 
   SETTINGS_PARAMS_SCHEMA = {
     'type': 'object',
@@ -258,6 +260,14 @@ class Account < ApplicationRecord
 
   def appointment_type_enabled?(type)
     available_appointment_types.include?(type.to_s)
+  end
+
+  def increment_product_catalog_version!
+    increment!(:product_catalog_version)
+  end
+
+  def product_catalog_full_sync_threshold
+    PRODUCT_CATALOG_FULL_SYNC_THRESHOLD
   end
 
   private

--- a/app/models/bulk_processing_request.rb
+++ b/app/models/bulk_processing_request.rb
@@ -51,6 +51,7 @@ class BulkProcessingRequest < ApplicationRecord
     pending: 'PENDING',
     processing: 'PROCESSING',
     completed: 'COMPLETED',
+    completed_with_warnings: 'COMPLETED_WITH_WARNINGS',
     failed: 'FAILED',
     partially_completed: 'PARTIALLY_COMPLETED',
     cancelled: 'CANCELLED'

--- a/app/models/kb_resource.rb
+++ b/app/models/kb_resource.rb
@@ -142,6 +142,7 @@ class KbResource < ApplicationRecord
     payload = {
       id: id,
       name: name,
+      description: description,
       s3_url: presigned_url
     }
     # Only include product_ids for create (no changed_attributes), for update it's in changed_attributes
@@ -173,7 +174,7 @@ class KbResource < ApplicationRecord
   end
 
   def dispatch_destroy_event
-    dispatch_resource_event(action: 'deleted', resource_data: { id: id, name: name })
+    dispatch_resource_event(action: 'deleted', resource_data: { id: id, name: name, description: description })
   end
 end
 

--- a/app/models/product_catalog.rb
+++ b/app/models/product_catalog.rb
@@ -149,14 +149,17 @@ class ProductCatalog < ApplicationRecord
   end
 
   def dispatch_create_event
+    account.increment_product_catalog_version!
     dispatch_product_event(target_account: account, added: 1, added_ids: [product_id])
   end
 
   def dispatch_update_event
+    account.increment_product_catalog_version!
     dispatch_product_event(target_account: account, updated: 1, updated_ids: [product_id])
   end
 
   def dispatch_destroy_event
+    account.increment_product_catalog_version!
     dispatch_product_event(target_account: account, deleted: 1, deleted_ids: [product_id])
   end
 

--- a/db/migrate/20260218125605_add_product_catalog_version_to_accounts.rb
+++ b/db/migrate/20260218125605_add_product_catalog_version_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddProductCatalogVersionToAccounts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :accounts, :product_catalog_version, :bigint, default: 0, null: false
+  end
+end


### PR DESCRIPTION
## Description

- Add catalog_version field to track catalog changes (bigint)
- Add full_sync_required flag when changes exceed threshold (500)
- Add total_changes count to webhook payload
- Fix webhook not firing when media URL downloads fail
- Add COMPLETED_WITH_WARNINGS status for successful products with media errors
- Add description field to kb_resource_updated webhook payload
- Increment catalog version on all product operations (create/update/delete/bulk)