### PR TITLE
fix: replace inline product search with dedicated search modal and pr…

### DIFF
--- a/app/controllers/api/v1/accounts/appointments_controller.rb
+++ b/app/controllers/api/v1/accounts/appointments_controller.rb
@@ -78,8 +78,12 @@ class Api::V1::Accounts::AppointmentsController < Api::V1::Accounts::BaseControl
       return render_error("Appointment type '#{appointment_type}' is not enabled for this account", :unprocessable_entity)
     end
 
+    conversation = find_conversation_from_params
+    return render_error('Conversation not found', :not_found) if conversation == false
+
     @appointment = contact.appointments.build(appointment_params)
     @appointment.account = Current.account
+    @appointment.conversation = conversation if conversation
 
     if @appointment.save
       generate_qr_code_for_appointment(@appointment)
@@ -244,6 +248,14 @@ class Api::V1::Accounts::AppointmentsController < Api::V1::Accounts::BaseControl
       errors: errors.full_messages,
       details: errors.messages
     }, status: :unprocessable_entity
+  end
+
+  def find_conversation_from_params
+    if params.dig(:appointment, :conversation_display_id).present?
+      Current.account.conversations.find_by(display_id: params.dig(:appointment, :conversation_display_id)) || false
+    elsif appointment_params[:conversation_id].present?
+      Current.account.conversations.find_by(id: appointment_params[:conversation_id]) || false
+    end
   end
 
   def render_error(message, status)

--- a/app/controllers/api/v1/accounts/microsoft/authorizations_controller.rb
+++ b/app/controllers/api/v1/accounts/microsoft/authorizations_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::Accounts::Microsoft::AuthorizationsController < Api::V1::Accounts
         redirect_uri: "#{base_url}/microsoft/callback",
         scope: scope,
         state: state,
-        prompt: 'consent'
+        prompt: 'select_account'
       }
     )
     if redirect_url

--- a/app/javascript/dashboard/components-next/KnowledgeBase/Pages/ProductCatalogPage/MediaDrawer.vue
+++ b/app/javascript/dashboard/components-next/KnowledgeBase/Pages/ProductCatalogPage/MediaDrawer.vue
@@ -4,7 +4,7 @@
     <Transition name="fade">
       <div
         v-if="product"
-        class="fixed inset-0 z-40 bg-black bg-opacity-50"
+        class="fixed inset-0 z-[70] bg-black bg-opacity-50"
         @click="emit('close')"
       />
     </Transition>
@@ -13,7 +13,7 @@
     <Transition name="slide-right">
       <div
         v-if="product"
-        class="fixed inset-y-0 right-0 z-50 w-full max-w-2xl bg-n-background border-l border-n-weak shadow-2xl flex flex-col"
+        class="fixed inset-y-0 right-0 z-[80] w-full max-w-2xl bg-n-background border-l border-n-weak shadow-2xl flex flex-col"
         @click.stop
       >
     <!-- Header -->

--- a/app/javascript/dashboard/components-next/KnowledgeBase/ProductSearchModal.vue
+++ b/app/javascript/dashboard/components-next/KnowledgeBase/ProductSearchModal.vue
@@ -1,0 +1,286 @@
+<script setup>
+import { ref, computed, watch, onUnmounted } from 'vue';
+import { useI18n } from 'vue-i18n';
+import Icon from 'dashboard/components-next/icon/Icon.vue';
+
+const props = defineProps({
+  modelValue: {
+    type: Array,
+    default: () => [],
+  },
+  products: {
+    type: Array,
+    default: () => [],
+  },
+  open: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['update:modelValue', 'update:open', 'preview']);
+
+const { t } = useI18n();
+
+const search = ref('');
+const searchDebounceTimer = ref(null);
+const debouncedSearch = ref('');
+
+const selectedProducts = computed(() => {
+  return props.products.filter(p => props.modelValue.includes(p.id));
+});
+
+const filteredProducts = computed(() => {
+  if (!debouncedSearch.value) {
+    return props.products.slice(0, 100);
+  }
+  const term = debouncedSearch.value.toLowerCase();
+  return props.products
+    .filter(p => {
+      const productId = p.product_id?.toLowerCase() || '';
+      const name = p.productName?.toLowerCase() || '';
+      return productId.includes(term) || name.includes(term);
+    })
+    .slice(0, 100);
+});
+
+const isSelected = id => props.modelValue.includes(id);
+
+const toggleProduct = product => {
+  const currentIds = [...props.modelValue];
+  const index = currentIds.indexOf(product.id);
+  if (index > -1) {
+    currentIds.splice(index, 1);
+  } else {
+    currentIds.push(product.id);
+  }
+  emit('update:modelValue', currentIds);
+};
+
+const selectAll = () => {
+  const allIds = props.products.map(p => p.id);
+  emit('update:modelValue', allIds);
+};
+
+const deselectAll = () => {
+  emit('update:modelValue', []);
+};
+
+const close = () => {
+  emit('update:open', false);
+};
+
+const handlePreview = product => {
+  emit('preview', product);
+};
+
+// Debounce search
+watch(search, newVal => {
+  if (searchDebounceTimer.value) {
+    clearTimeout(searchDebounceTimer.value);
+  }
+  searchDebounceTimer.value = setTimeout(() => {
+    debouncedSearch.value = newVal;
+  }, 300);
+});
+
+// Reset search when modal closes
+watch(
+  () => props.open,
+  val => {
+    if (!val) {
+      search.value = '';
+      debouncedSearch.value = '';
+    }
+  }
+);
+
+onUnmounted(() => {
+  if (searchDebounceTimer.value) {
+    clearTimeout(searchDebounceTimer.value);
+  }
+});
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="fade">
+      <div
+        v-if="open"
+        class="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/50"
+        @click.self="close"
+      >
+        <div
+          class="w-full max-w-2xl bg-n-background rounded-xl border border-n-weak shadow-xl flex flex-col max-h-[85vh] overflow-hidden"
+          @click.stop
+        >
+          <!-- Header -->
+          <div
+            class="flex items-center justify-between px-5 py-4 border-b border-n-weak"
+          >
+            <h3 class="text-base font-medium text-n-slate-12">
+              {{ t('KNOWLEDGE_BASE.RESOURCES.PRODUCT_SEARCH.MODAL_TITLE') }}
+            </h3>
+            <button
+              type="button"
+              class="p-1 text-n-slate-11 hover:text-n-slate-12 hover:bg-n-alpha-2 rounded-lg"
+              @click="close"
+            >
+              <Icon icon="i-lucide-x" class="w-5 h-5" />
+            </button>
+          </div>
+
+          <!-- Search bar -->
+          <div class="px-5 py-3 border-b border-n-weak">
+            <div
+              class="flex items-center gap-3 px-3 py-2.5 border border-n-weak rounded-lg bg-n-alpha-1 focus-within:border-n-blue-9 transition-colors"
+            >
+              <Icon
+                icon="i-lucide-search"
+                class="w-5 h-5 text-n-slate-10 shrink-0"
+              />
+              <input
+                v-model="search"
+                type="text"
+                :placeholder="
+                  t('KNOWLEDGE_BASE.RESOURCES.PRODUCT_SEARCH.PLACEHOLDER')
+                "
+                class="flex-1 bg-transparent border-none outline-none text-sm text-n-slate-12 placeholder:text-n-slate-9"
+              />
+            </div>
+            <!-- Quick actions + counter -->
+            <div class="flex items-center justify-between mt-2">
+              <span class="text-xs text-n-slate-10">
+                {{ selectedProducts.length }} / {{ products.length }}
+                {{ t('KNOWLEDGE_BASE.RESOURCES.PRODUCT_SEARCH.SELECTED') }}
+              </span>
+              <div class="flex items-center gap-2">
+                <button
+                  type="button"
+                  class="text-xs text-n-blue-11 hover:text-n-blue-12 font-medium"
+                  @click="selectAll"
+                >
+                  {{
+                    t('KNOWLEDGE_BASE.RESOURCES.PRODUCT_SEARCH.SELECT_ALL')
+                  }}
+                </button>
+                <span class="text-n-slate-8">|</span>
+                <button
+                  type="button"
+                  class="text-xs text-n-slate-11 hover:text-n-slate-12 font-medium"
+                  @click="deselectAll"
+                >
+                  {{
+                    t('KNOWLEDGE_BASE.RESOURCES.PRODUCT_SEARCH.DESELECT_ALL')
+                  }}
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <!-- Product list -->
+          <div class="flex-1 overflow-y-auto">
+            <div
+              v-if="filteredProducts.length === 0"
+              class="p-8 text-center text-sm text-n-slate-11"
+            >
+              {{ t('KNOWLEDGE_BASE.RESOURCES.PRODUCT_SEARCH.NO_RESULTS') }}
+            </div>
+
+            <div
+              v-for="product in filteredProducts"
+              :key="product.id"
+              class="flex items-center gap-3 px-5 py-3 border-b border-n-weak/50 last:border-b-0 hover:bg-n-alpha-2 transition-colors"
+              :class="{ 'bg-n-blue-2': isSelected(product.id) }"
+            >
+              <!-- Checkbox -->
+              <button
+                type="button"
+                class="shrink-0"
+                @click="toggleProduct(product)"
+              >
+                <div
+                  class="w-4 h-4 rounded border flex items-center justify-center transition-colors"
+                  :class="
+                    isSelected(product.id)
+                      ? 'bg-n-blue-9 border-n-blue-9'
+                      : 'border-n-slate-8'
+                  "
+                >
+                  <Icon
+                    v-if="isSelected(product.id)"
+                    icon="i-lucide-check"
+                    class="w-3 h-3 text-white"
+                  />
+                </div>
+              </button>
+
+              <!-- Product info (clickable to toggle) -->
+              <button
+                type="button"
+                class="flex-1 min-w-0 text-left"
+                @click="toggleProduct(product)"
+              >
+                <div class="flex items-center gap-2">
+                  <span
+                    class="font-mono text-xs bg-n-slate-3 px-1.5 py-0.5 rounded text-n-slate-11"
+                  >
+                    {{ product.product_id }}
+                  </span>
+                  <span
+                    class="text-sm font-medium text-n-slate-12 truncate"
+                  >
+                    {{ product.productName }}
+                  </span>
+                </div>
+                <div class="text-xs text-n-slate-10 mt-0.5">
+                  {{ product.type }}
+                  <span v-if="product.industry">
+                    · {{ product.industry }}
+                  </span>
+                </div>
+              </button>
+
+              <!-- Eye icon for preview -->
+              <button
+                type="button"
+                class="shrink-0 p-1.5 text-n-slate-10 hover:text-n-blue-11 hover:bg-n-alpha-2 rounded-lg transition-colors"
+                :title="
+                  t('KNOWLEDGE_BASE.RESOURCES.PRODUCT_SEARCH.VIEW_DETAILS')
+                "
+                @click.stop="handlePreview(product)"
+              >
+                <Icon icon="i-lucide-eye" class="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+
+          <!-- Footer -->
+          <div
+            class="flex items-center justify-end px-5 py-3 border-t border-n-weak"
+          >
+            <button
+              type="button"
+              class="px-4 py-2 bg-n-blue-9 hover:bg-n-blue-10 text-white text-sm font-medium rounded-lg transition-colors"
+              @click="close"
+            >
+              {{ t('KNOWLEDGE_BASE.RESOURCES.PRODUCT_SEARCH.DONE') }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/app/javascript/dashboard/components-next/KnowledgeBase/ProductSearchSelect.vue
+++ b/app/javascript/dashboard/components-next/KnowledgeBase/ProductSearchSelect.vue
@@ -18,7 +18,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(['update:modelValue']);
+const emit = defineEmits(['update:modelValue', 'open-search-modal']);
 
 const { t } = useI18n();
 
@@ -116,7 +116,13 @@ onUnmounted(() => {
     <div class="flex items-center gap-2 px-3 py-2 border-b border-n-weak bg-n-alpha-1">
       <!-- Search input -->
       <div class="flex-1 flex items-center gap-2">
-        <Icon icon="i-lucide-search" class="w-4 h-4 text-n-slate-10 shrink-0" />
+        <button
+          type="button"
+          class="shrink-0 p-0.5 hover:bg-n-alpha-2 rounded transition-colors"
+          @click.stop="emit('open-search-modal')"
+        >
+          <Icon icon="i-lucide-search" class="w-4 h-4 text-n-slate-10" />
+        </button>
         <input
           v-model="search"
           type="text"

--- a/app/javascript/dashboard/components-next/KnowledgeBase/ResourceDetailDrawer.vue
+++ b/app/javascript/dashboard/components-next/KnowledgeBase/ResourceDetailDrawer.vue
@@ -12,7 +12,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(['close', 'edit', 'delete', 'toggle-visibility', 'move']);
+const emit = defineEmits(['close', 'edit', 'delete', 'toggle-visibility', 'move', 'preview-product']);
 
 const { t } = useI18n();
 const router = useRouter();
@@ -249,12 +249,10 @@ const handleKeydown = (event) => {
 
                   <!-- Products list -->
                   <div v-else>
-                    <button
+                    <div
                       v-for="product in paginatedProducts"
                       :key="product.id"
-                      type="button"
-                      class="w-full flex items-center gap-3 px-3 py-2.5 hover:bg-n-alpha-2 transition-colors text-left border-b border-n-weak/50 last:border-b-0"
-                      @click="navigateToProduct(product)"
+                      class="flex items-center gap-3 px-3 py-2.5 hover:bg-n-alpha-2 transition-colors text-left border-b border-n-weak/50 last:border-b-0"
                     >
                       <div class="flex-1 min-w-0">
                         <div class="flex items-center gap-2">
@@ -269,8 +267,15 @@ const handleKeydown = (event) => {
                           {{ product.type }} <span v-if="product.industry">· {{ product.industry }}</span>
                         </div>
                       </div>
-                      <i class="i-lucide-external-link w-4 h-4 text-n-slate-10 flex-shrink-0" />
-                    </button>
+                      <button
+                        type="button"
+                        class="p-1.5 text-n-slate-10 hover:text-n-blue-11 hover:bg-n-alpha-2 rounded-lg transition-colors flex-shrink-0"
+                        :title="t('KNOWLEDGE_BASE.RESOURCES.PRODUCT_SEARCH.VIEW_DETAILS')"
+                        @click="emit('preview-product', product)"
+                      >
+                        <i class="i-lucide-eye w-4 h-4" />
+                      </button>
+                    </div>
 
                     <!-- Pagination -->
                     <div

--- a/app/javascript/dashboard/i18n/locale/en/agentBots.json
+++ b/app/javascript/dashboard/i18n/locale/en/agentBots.json
@@ -126,6 +126,8 @@
         "SECTION_IDENTITY_DESC": "Basic information about this agent: name, description and webhook endpoint.",
         "SECTION_INDUSTRY": "Industry / Sector",
         "SECTION_INDUSTRY_DESC": "Determines the default tools and catalogue examples for this agent.",
+        "SECTION_ACCESS_TOKEN": "Access Token",
+        "SECTION_ACCESS_TOKEN_DESC": "Use this token to authenticate requests from your webhook to the agent API.",
         "NAME_LABEL": "Agent name",
         "NAME_PLACEHOLDER": "e.g. Toyota Polanco WhatsApp",
         "DESCRIPTION_LABEL": "AI agent description",

--- a/app/javascript/dashboard/i18n/locale/en/knowledgeBase.json
+++ b/app/javascript/dashboard/i18n/locale/en/knowledgeBase.json
@@ -391,7 +391,10 @@
         "AVAILABLE": "products available",
         "SELECT_ALL": "Select all",
         "DESELECT_ALL": "Deselect all",
-        "SELECTED": "selected"
+        "SELECTED": "selected",
+        "MODAL_TITLE": "Search Products",
+        "VIEW_DETAILS": "View details",
+        "DONE": "Done"
       },
       "VIEW": {
         "LIST": "List view",

--- a/app/javascript/dashboard/i18n/locale/es/knowledgeBase.json
+++ b/app/javascript/dashboard/i18n/locale/es/knowledgeBase.json
@@ -391,7 +391,10 @@
         "AVAILABLE": "productos disponibles",
         "SELECT_ALL": "Seleccionar todos",
         "DESELECT_ALL": "Deseleccionar todos",
-        "SELECTED": "seleccionados"
+        "SELECTED": "seleccionados",
+        "MODAL_TITLE": "Buscar Productos",
+        "VIEW_DETAILS": "Ver detalles",
+        "DONE": "Listo"
       },
       "VIEW": {
         "LIST": "Vista de lista",

--- a/app/javascript/dashboard/routes/dashboard/knowledge-base/pages/ResourcesPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/knowledge-base/pages/ResourcesPage.vue
@@ -914,7 +914,7 @@ onMounted(fetchData);
             @click.self="showUploadModal = false"
           >
             <div
-              class="w-full max-w-md bg-n-alpha-3 backdrop-blur-[100px] rounded-xl border border-n-weak shadow-md flex flex-col max-h-[90vh] overflow-hidden"
+              class="w-full max-w-[95vw] sm:max-w-[40vw] sm:min-w-[500px] bg-n-alpha-3 backdrop-blur-[100px] rounded-xl border border-n-weak shadow-md flex flex-col max-h-[90vh] overflow-hidden"
               @click.stop
             >
               <div class="flex items-center justify-between p-4 sm:p-6 shrink-0">
@@ -1664,7 +1664,7 @@ onMounted(fetchData);
         @click.self="showEditModal = false"
       >
         <div
-          class="w-full max-w-md bg-n-alpha-3 backdrop-blur-[100px] rounded-xl border border-n-weak shadow-md flex flex-col max-h-[90vh] overflow-hidden"
+          class="w-full max-w-[95vw] sm:max-w-[40vw] sm:min-w-[500px] bg-n-alpha-3 backdrop-blur-[100px] rounded-xl border border-n-weak shadow-md flex flex-col max-h-[90vh] overflow-hidden"
           @click.stop
         >
           <div class="flex items-center justify-between p-4 sm:p-6 shrink-0">

--- a/app/javascript/dashboard/routes/dashboard/knowledge-base/pages/ResourcesPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/knowledge-base/pages/ResourcesPage.vue
@@ -12,6 +12,8 @@ import Button from 'dashboard/components-next/button/Button.vue';
 import Input from 'dashboard/components-next/input/Input.vue';
 import Icon from 'dashboard/components-next/icon/Icon.vue';
 import ProductSearchSelect from 'dashboard/components-next/KnowledgeBase/ProductSearchSelect.vue';
+import ProductSearchModal from 'dashboard/components-next/KnowledgeBase/ProductSearchModal.vue';
+import MediaDrawer from 'dashboard/components-next/KnowledgeBase/Pages/ProductCatalogPage/MediaDrawer.vue';
 import ResourceDetailDrawer from 'dashboard/components-next/KnowledgeBase/ResourceDetailDrawer.vue';
 import TreeNode from 'dashboard/components-next/KnowledgeBase/TreeNode.vue';
 
@@ -27,6 +29,24 @@ const resourceToDelete = ref(null);
 
 // Drawer state
 const selectedResource = ref(null);
+
+// Product search modal state
+const showProductSearchModal = ref(false);
+const selectedProductForPreview = ref(null);
+
+const activeProductCatalogIds = computed({
+  get() {
+    if (showEditModal.value) return editForm.value.product_catalog_ids;
+    return uploadForm.value.product_catalog_ids;
+  },
+  set(val) {
+    if (showEditModal.value) {
+      editForm.value.product_catalog_ids = val;
+    } else {
+      uploadForm.value.product_catalog_ids = val;
+    }
+  },
+});
 
 // View mode: 'list' (S3-like navigation) or 'tree' (2D tree view)
 const viewMode = ref('list');
@@ -1026,6 +1046,7 @@ onMounted(fetchData);
                           v-model="uploadForm.product_catalog_ids"
                           :products="productCatalogs"
                           :placeholder="t('KNOWLEDGE_BASE.RESOURCES.PRODUCT_SEARCH.PLACEHOLDER')"
+                          @open-search-modal="showProductSearchModal = true"
                         />
                       </div>
                     </div>
@@ -1740,6 +1761,7 @@ onMounted(fetchData);
                       v-model="editForm.product_catalog_ids"
                       :products="productCatalogs"
                       :placeholder="t('KNOWLEDGE_BASE.RESOURCES.PRODUCT_SEARCH.PLACEHOLDER')"
+                      @open-search-modal="showProductSearchModal = true"
                     />
                   </div>
                 </div>
@@ -1797,6 +1819,7 @@ onMounted(fetchData);
       @delete="confirmDelete"
       @toggle-visibility="toggleVisibility"
       @move="openMoveModal"
+      @preview-product="selectedProductForPreview = $event"
     />
 
     <!-- Create Folder Modal (z-60 to appear above Move modal) -->
@@ -2029,5 +2052,20 @@ onMounted(fetchData);
         </div>
       </div>
     </Teleport>
+
+    <!-- Product search modal (above upload/edit modals) -->
+    <ProductSearchModal
+      v-model="activeProductCatalogIds"
+      :products="productCatalogs"
+      :open="showProductSearchModal"
+      @update:open="showProductSearchModal = $event"
+      @preview="selectedProductForPreview = $event"
+    />
+
+    <!-- Product detail drawer (above search modal) -->
+    <MediaDrawer
+      :product="selectedProductForPreview"
+      @close="selectedProductForPreview = null"
+    />
   </div>
 </template>

--- a/app/javascript/dashboard/routes/dashboard/settings/agentBots/AgentConfigPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/agentBots/AgentConfigPage.vue
@@ -7,6 +7,7 @@ import { useRoute } from 'vue-router';
 
 import Button from 'dashboard/components-next/button/Button.vue';
 import Spinner from 'dashboard/components-next/spinner/Spinner.vue';
+import { copyTextToClipboard } from 'shared/helpers/clipboard';
 import SettingIntroBanner from 'dashboard/components/widgets/SettingIntroBanner.vue';
 import TabGeneral from './tabs/TabGeneral.vue';
 import TabAssistant from './tabs/TabAssistant.vue';
@@ -109,6 +110,7 @@ const formState = reactive({
   google_api_key: '',
   has_openai_api_key: false,
   has_google_api_key: false,
+  access_token: '',
 });
 
 const initForm = () => {
@@ -123,6 +125,7 @@ const initForm = () => {
   formState.has_google_api_key = b.has_google_api_key || false;
   formState.openai_api_key = '';
   formState.google_api_key = '';
+  formState.access_token = b.access_token || '';
 
   const ac = b.assistant_config || {};
   Object.assign(formState.assistant_config, defaultAssistantConfig(), ac);
@@ -191,6 +194,21 @@ const handleSave = async () => {
   else useAlert(t('AGENT_BOTS.CONFIG.ERROR_MESSAGE'));
 };
 
+const handleCopyToken = async value => {
+  await copyTextToClipboard(value);
+  useAlert(t('AGENT_BOTS.ACCESS_TOKEN.COPY_SUCCESSFUL'));
+};
+
+const handleResetToken = async () => {
+  const result = await store.dispatch('agentBots/resetAccessToken', botId.value);
+  if (result) {
+    formState.access_token = result.access_token || '';
+    useAlert(t('AGENT_BOTS.ACCESS_TOKEN.RESET_SUCCESS'));
+  } else {
+    useAlert(t('AGENT_BOTS.ACCESS_TOKEN.RESET_ERROR'));
+  }
+};
+
 onMounted(async () => {
   await store.dispatch('agentBots/show', botId.value);
   initForm();
@@ -236,7 +254,13 @@ onMounted(async () => {
 
     <section v-else class="mx-auto w-full max-w-6xl">
       <div class="mx-8">
-        <TabGeneral v-if="selectedTabIndex === 0" :form="formState" />
+        <TabGeneral
+          v-if="selectedTabIndex === 0"
+          :form="formState"
+          :access-token="formState.access_token"
+          @copy-token="handleCopyToken"
+          @reset-token="handleResetToken"
+        />
         <TabAssistant v-else-if="selectedTabIndex === 1" :form="formState" />
         <TabModel v-else-if="selectedTabIndex === 2" :form="formState" />
         <TabCapabilities v-else-if="selectedTabIndex === 3" :form="formState" />

--- a/app/javascript/dashboard/routes/dashboard/settings/agentBots/tabs/TabGeneral.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/agentBots/tabs/TabGeneral.vue
@@ -5,10 +5,14 @@ import { useI18n } from 'vue-i18n';
 import SettingsSection from 'dashboard/components/SettingsSection.vue';
 import Input from 'dashboard/components-next/input/Input.vue';
 import TextArea from 'dashboard/components-next/textarea/TextArea.vue';
+import AccessToken from 'dashboard/routes/dashboard/settings/profile/AccessToken.vue';
 
 const props = defineProps({
   form: { type: Object, required: true },
+  accessToken: { type: String, default: '' },
 });
+
+const emit = defineEmits(['copyToken', 'resetToken']);
 
 const { t } = useI18n();
 
@@ -155,6 +159,19 @@ const currentIndustryLabel = computed(() => {
           {{ $t('AGENT_BOTS.CONFIG.GENERAL.INDUSTRY_HINT') }}
         </p>
       </div>
+    </SettingsSection>
+
+    <SettingsSection
+      :title="$t('AGENT_BOTS.CONFIG.GENERAL.SECTION_ACCESS_TOKEN')"
+      :sub-title="$t('AGENT_BOTS.CONFIG.GENERAL.SECTION_ACCESS_TOKEN_DESC')"
+      :show-border="false"
+    >
+      <AccessToken
+        :value="accessToken"
+        :show-reset-button="true"
+        @on-copy="emit('copyToken', $event)"
+        @on-reset="emit('resetToken')"
+      />
     </SettingsSection>
   </div>
 </template>

--- a/app/jobs/enroll_notion_database_records_job.rb
+++ b/app/jobs/enroll_notion_database_records_job.rb
@@ -235,26 +235,28 @@ class EnrollNotionDatabaseRecordsJob < ApplicationJob
 
     existing_conversation = contact_inbox.conversations.last
     if existing_conversation
-      Rails.logger.info "Using existing conversation #{existing_conversation.id} for contact #{contact.id}"
+      if existing_conversation.resolved?
+        Rails.logger.info "Existing conversation #{existing_conversation.id} is resolved, creating new conversation for contact #{contact.id}"
+      else
+        Rails.logger.info "Using existing conversation #{existing_conversation.id} for contact #{contact.id}"
 
-      # Solo enviamos el primer contacto si no tiene una secuencia activa actualmente
-      # Si está completada, revisamos si se permite el re-enrollment
-      follow_up = existing_conversation.conversation_follow_up
-      include_completed = sequence.trigger_conditions.dig('enrollment_filter', 'include_completed')
+        # Solo enviamos el primer contacto si no tiene una secuencia activa actualmente
+        # Si está completada, revisamos si se permite el re-enrollment
+        follow_up = existing_conversation.conversation_follow_up
+        include_completed = sequence.trigger_conditions.dig('enrollment_filter', 'include_completed')
 
-      should_send = if follow_up&.status == 'active'
-                      false
-                    elsif follow_up&.status == 'completed'
-                      include_completed
-                    else
-                      true # nil, cancelled, failed, etc.
-                    end
+        should_send = if follow_up&.status == 'active'
+                        false
+                      elsif follow_up&.status == 'completed'
+                        include_completed
+                      else
+                        true # nil, cancelled, failed, etc.
+                      end
 
-      if should_send
-        send_first_contact_message(sequence, existing_conversation, contact, record)
+        send_first_contact_message(sequence, existing_conversation, contact, record) if should_send
+
+        return existing_conversation
       end
-
-      return existing_conversation
     end
 
     # Create new conversation

--- a/app/listeners/agent_bot_listener.rb
+++ b/app/listeners/agent_bot_listener.rb
@@ -118,7 +118,8 @@ class AgentBotListener < BaseListener
     attempts = config['attempts'] || []
     return if attempts.empty?
 
-    if reengagement && !reengagement.excluded_from_reactivation?(reengagement.status)
+    if reengagement && reengagement.status.start_with?('cancelled_') &&
+       !reengagement.excluded_from_reactivation?(reengagement.status)
       reengagement.reactivate!(trigger_started_at: message.created_at)
     elsif reengagement.nil?
       ConversationReengagement.create!(

--- a/app/policies/appointment_policy.rb
+++ b/app/policies/appointment_policy.rb
@@ -27,11 +27,23 @@ class AppointmentPolicy < ApplicationPolicy
     true
   end
 
-  def search?
-    true
+  def start?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 
-  def filter?
-    true
+  def complete?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
+  end
+
+  def cancel?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
+  end
+
+  def mark_no_show?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
+  end
+
+  def available_types?
+    @account_user.administrator? || @account_user.supervisor? || @account_user.agent?
   end
 end


### PR DESCRIPTION
The product search bar inside the Upload/Edit resource modals was too small. Now clicking the search icon opens a larger dedicated modal (ProductSearchModal) with a full search bar, product list with checkboxes for selection, and an eye icon on each card to preview product details via the existing MediaDrawer panel. The same preview functionality was added to the resource detail drawer product list.