### PR TITLE
fix(whatsapp): deliver appointment QR images by encoding PNG as RGB 8…

### DIFF
--- a/app/controllers/concerns/appointment_qr_generator.rb
+++ b/app/controllers/concerns/appointment_qr_generator.rb
@@ -7,22 +7,16 @@ module AppointmentQrGenerator
   def generate_qr_code_for_appointment(appointment)
     customer_url = frontend_url("accounts/#{appointment.account_id}/customers/#{appointment.contact.id}?token=#{appointment.access_token}")
 
-    qr_code = RQRCode::QRCode.new(customer_url)
-    png = qr_code.as_png(
-      bit_depth: 1,
+    png = RQRCode::QRCode.new(customer_url).as_png(
       border_modules: 4,
-      color_mode: ChunkyPNG::COLOR_GRAYSCALE,
       color: 'black',
-      file: nil,
       fill: 'white',
       module_px_size: 6,
-      resize_exactly_to: false,
-      resize_gte_to: false,
       size: 300
-    )
+    ).to_blob(color_mode: ChunkyPNG::COLOR_TRUECOLOR, bit_depth: 8)
 
     appointment.qr_code.attach(
-      io: StringIO.new(png.to_s),
+      io: StringIO.new(png),
       filename: "appointment_#{appointment.id}_qr.png",
       content_type: 'image/png'
     )

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -117,12 +117,13 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
   end
 
   def send_attachment_message(phone_number, message)
+    last_message_id = nil
     message.attachments.each_with_index do |attachment, index|
       type = %w[image audio video].include?(attachment.file_type) ? attachment.file_type : 'document'
       type_content = {
         'link': attachment.download_url
       }
-      type_content['caption'] = message.outgoing_content if index.zero? && !%w[audio sticker].include?(type)
+      type_content['caption'] = message.outgoing_content if index.zero? && !%w[audio sticker].include?(type) && message.outgoing_content.present?
       type_content['filename'] = attachment.file.filename if type == 'document'
       response = HTTParty.post(
         "#{phone_id_path}/messages",
@@ -136,8 +137,9 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
         }.to_json
       )
 
-      process_response(response, message)
+      last_message_id = process_response(response, message)
     end
+    last_message_id
   end
 
   def error_message(response)


### PR DESCRIPTION
…-bit

The appointment QR generator produced 1-bit grayscale PNG, which Meta WhatsApp Cloud rejects asynchronously with error 131053 "Image is invalid... supported are PNG, RGB/RGBA, up to 8 bit/channel". Meta returned wamid on the POST sync, but the message status:failed only arrived later via webhook, so the dashboard kept showing the message as "sent" while it never reached the recipient.

Passing color_mode/bit_depth to as_png() does not propagate to the PNG serialization step — ChunkyPNG auto-optimizes B&W images to 1-bit grayscale on .to_blob/.to_s. The fix is to pass the encoding options to .to_blob.

Also fix two related bugs in WhatsappCloudService#send_attachment_message surfaced while debugging:
- Return the last wamid from the attachment loop instead of the attachments collection, so message.source_id stops being stored as the inspect string of the proxy and delivery webhooks can match by wamid.
- Skip the caption field entirely when message has no text content, instead of sending caption: null (Meta tolerates it but the upstream pattern is to omit unset optional fields).

# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
