### PR TITLE
fix(copilots): align first_contact webhook payload with follow-up shape

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -1228,7 +1228,7 @@
         "EMAIL_INBOX": "Email Inbox (optional)",
         "SELECT_EMAIL_INBOX": "Use conversation inbox (default)...",
         "SENDER_EMAIL": "Sender Email (optional)",
-        "SENDER_EMAIL_PLACEHOLDER": "e.g., support@yourcompany.com",
+        "SENDER_EMAIL_PLACEHOLDER": "e.g., support{'@'}yourcompany.com",
         "SUBJECT": "Email Subject (optional)",
         "SUBJECT_PLACEHOLDER": "If left blank, AI will generate the subject...",
         "CONTENT": "Email Content (optional)",

--- a/app/jobs/enroll_notion_database_records_job.rb
+++ b/app/jobs/enroll_notion_database_records_job.rb
@@ -707,27 +707,24 @@ class EnrollNotionDatabaseRecordsJob < ApplicationJob
     agent_bot = conversation.inbox.agent_bot
     raise "No agent bot configured for inbox #{conversation.inbox.id}" unless agent_bot
 
-    # Construir contexto con variables de Notion
-    context = build_context_with_notion_variables(config['sms_context'] || '', record, sequence)
+    contact = conversation.contact
+    step = sequence.steps.find { |s| s['type'] == 'first_contact' }
 
-    payload = {
-      event: 'lead_followup.first_contact_request',
-      conversation_id: conversation.id,
-      agent_bot_id: agent_bot.id,
+    rendered_context = render_param_value(config['sms_context'] || '', contact, record, sequence)
+
+    payload = build_first_contact_payload(
+      sequence: sequence,
+      conversation: conversation,
+      contact: contact,
+      step: step,
+      record: record,
       channel: 'whatsapp',
-      context: context,
-      notion_data: extract_notion_data(record, sequence)
-    }
+      reply_inbox: conversation.inbox,
+      context: rendered_context,
+      variables: {}
+    )
 
-    # Enviar webhook al agent bot
-    webhook_url = agent_bot.outgoing_url
-    HTTParty.post(webhook_url, {
-      body: payload.to_json,
-      headers: { 'Content-Type' => 'application/json' },
-      timeout: 30
-    })
-
-    Rails.logger.info "Sent AI first contact request for conversation #{conversation.id}"
+    post_first_contact_webhook(agent_bot, payload, 'whatsapp', conversation.id)
   rescue StandardError => e
     Rails.logger.error "Failed to send AI first contact: #{e.message}"
     raise
@@ -737,25 +734,24 @@ class EnrollNotionDatabaseRecordsJob < ApplicationJob
     agent_bot = conversation.inbox.agent_bot
     raise "No agent bot configured for inbox #{conversation.inbox.id}" unless agent_bot
 
-    context = build_context_with_notion_variables(config['sms_context'] || '', record, sequence)
+    contact = conversation.contact
+    step = sequence.steps.find { |s| s['type'] == 'first_contact' }
 
-    payload = {
-      event: 'lead_followup.first_contact_request',
-      conversation_id: conversation.id,
-      agent_bot_id: agent_bot.id,
+    rendered_context = render_param_value(config['sms_context'] || '', contact, record, sequence)
+
+    payload = build_first_contact_payload(
+      sequence: sequence,
+      conversation: conversation,
+      contact: contact,
+      step: step,
+      record: record,
       channel: 'sms',
-      context: context,
-      notion_data: extract_notion_data(record, sequence)
-    }
+      reply_inbox: conversation.inbox,
+      context: rendered_context,
+      variables: {}
+    )
 
-    webhook_url = agent_bot.outgoing_url
-    HTTParty.post(webhook_url, {
-      body: payload.to_json,
-      headers: { 'Content-Type' => 'application/json' },
-      timeout: 30
-    })
-
-    Rails.logger.info "Sent SMS first contact request for conversation #{conversation.id}"
+    post_first_contact_webhook(agent_bot, payload, 'sms', conversation.id)
   rescue StandardError => e
     Rails.logger.error "Failed to send SMS first contact: #{e.message}"
     raise
@@ -768,34 +764,84 @@ class EnrollNotionDatabaseRecordsJob < ApplicationJob
     agent_bot = inbox.agent_bot
     raise "No agent bot configured for email inbox #{inbox.id}" unless agent_bot
 
-    context = build_context_with_notion_variables(config['email_context'] || '', record, sequence)
+    step = sequence.steps.find { |s| s['type'] == 'first_contact' }
+
+    rendered_context = render_param_value(config['email_context'] || '', contact, record, sequence)
+    rendered_subject = render_param_value(config['subject'] || '', contact, record, sequence)
+    rendered_content = render_param_value(config['content'] || '', contact, record, sequence)
     sender_email = config['sender_email'].presence || sequence.account.support_email
 
-    payload = {
-      event: 'lead_followup.first_contact_request',
-      conversation_id: conversation.id,
-      agent_bot_id: agent_bot.id,
+    payload = build_first_contact_payload(
+      sequence: sequence,
+      conversation: conversation,
+      contact: contact,
+      step: step,
+      record: record,
       channel: 'email',
-      context: context,
+      reply_inbox: inbox,
+      context: rendered_context,
       variables: {
         to_email: contact.email,
         sender_email: sender_email,
-        subject: config['subject'],
-        content: config['content']
-      },
-      notion_data: extract_notion_data(record, sequence)
-    }
+        subject: rendered_subject,
+        content: rendered_content
+      }
+    )
 
+    post_first_contact_webhook(agent_bot, payload, 'email', conversation.id)
+  rescue StandardError => e
+    Rails.logger.error "Failed to send email first contact: #{e.message}"
+    raise
+  end
+
+  def build_first_contact_payload(sequence:, conversation:, contact:, step:, record:, channel:, reply_inbox:, context:, variables:)
+    last_message = conversation.messages.where.not(message_type: :activity).order(created_at: :desc).first
+    last_message_timestamp = last_message&.created_at&.to_i
+
+    {
+      event: 'lead_followup.first_contact_request',
+      idempotency_key: generate_first_contact_idempotency_key(sequence: sequence, record: record, step: step),
+      account: sequence.account.webhook_data,
+      inbox: conversation.inbox.webhook_data,
+      conversation: conversation.webhook_data.merge(
+        last_activity_at: conversation.last_activity_at.to_i,
+        last_message_at: last_message_timestamp
+      ),
+      contact: contact.push_event_data,
+      follow_up_data: {
+        sequence_id: sequence.id,
+        sequence_name: sequence.name,
+        step_id: step&.dig('id'),
+        step_name: step&.dig('name'),
+        current_step: 0,
+        message_channel: channel,
+        reply_inbox: {
+          id: reply_inbox.id,
+          name: reply_inbox.name,
+          channel_type: reply_inbox.channel_type,
+          phone_number: reply_inbox.channel&.try(:phone_number),
+          email: reply_inbox.channel&.try(:email)
+        },
+        context: context,
+        variables: variables,
+        notion_data: extract_notion_data(record, sequence)
+      }
+    }
+  end
+
+  def generate_first_contact_idempotency_key(sequence:, record:, step:)
+    base = "first_contact-#{sequence.id}-#{record[:id]}-#{step&.dig('id')}"
+    Digest::SHA256.hexdigest(base)
+  end
+
+  def post_first_contact_webhook(agent_bot, payload, channel, conversation_id)
     HTTParty.post(agent_bot.outgoing_url, {
       body: payload.to_json,
       headers: { 'Content-Type' => 'application/json' },
       timeout: 30
     })
 
-    Rails.logger.info "Sent email first contact request for conversation #{conversation.id}"
-  rescue StandardError => e
-    Rails.logger.error "Failed to send email first contact: #{e.message}"
-    raise
+    Rails.logger.info "Sent #{channel} first contact request for conversation #{conversation_id}"
   end
 
   def build_context_with_notion_variables(context, record, sequence)

--- a/app/models/lead_follow_up_sequence.rb
+++ b/app/models/lead_follow_up_sequence.rb
@@ -575,6 +575,8 @@ class LeadFollowUpSequence < ApplicationRecord
     }
   end
 
+  public
+
   # Determine if manual update is needed (usually no, if using counter_culture correctly)
   # Keeping this method signature to avoid breaking callers, but it simply returns current stats
   def update_stats!
@@ -583,6 +585,8 @@ class LeadFollowUpSequence < ApplicationRecord
     # rely on the consumer to use the new columns + calculate_stats.
     update_column(:stats, calculate_stats)
   end
+
+  private
 
   def notion_database?
     source_type == 'notion_database'


### PR DESCRIPTION
- Refactor send_*_first_contact in EnrollNotionDatabaseRecordsJob to emit the same payload shape as SendFollowUpService (account, inbox, conversation with display_id, contact, follow_up_data).
- Add unique idempotency_key per (sequence, notion_record, step) to avoid agent-side dedup collapse.
- Render {{contact.*}} and {{notion.*}} in subject/content/context server-side before posting the webhook.
- Make LeadFollowUpSequence#update_stats! public so the job can call it without raising NoMethodError after the webhook is sent.
- Escape @ in en/settings.json SENDER_EMAIL_PLACEHOLDER to avoid vue-i18n "Invalid linked format" SyntaxError.

# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
