### PR TITLE
feat(email): integrate Resend as email channel provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -177,6 +177,10 @@ GOOGLE_OAUTH_CLIENT_ID=
 GOOGLE_OAUTH_CLIENT_SECRET=
 GOOGLE_OAUTH_CALLBACK_URL=
 
+# Resend (email transport for inboxes using smtp.resend.com)
+RESEND_API_KEY=
+RESEND_INBOUND_WEBHOOK_SECRET=
+
 ### Change this env variable only if you are using a custom build mobile app
 ## Mobile app env variables
 IOS_APP_ID=L7YLMN4634.com.chatwoot.app

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ gem 'gmail_xoauth'
 gem 'net-smtp',  '~> 0.3.4'
 # Prevent CSV injection
 gem 'csv-safe'
+# Resend inbound webhook signature verification
+gem 'svix'
 # QR code generation
 gem 'rqrcode'
 # Excel file processing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -951,6 +951,9 @@ GEM
     stackprof (0.2.25)
     statsd-ruby (1.5.0)
     stripe (18.0.1)
+    svix (1.95.2)
+      base64 (~> 0.3.0)
+      logger (~> 1.0)
     telephone_number (1.4.20)
     test-prof (1.2.1)
     thor (1.4.0)
@@ -1171,6 +1174,7 @@ DEPENDENCIES
   squasher
   stackprof
   stripe (~> 18.0)
+  svix
   telephone_number
   test-prof
   tidewave

--- a/app/controllers/unsubscribe_controller.rb
+++ b/app/controllers/unsubscribe_controller.rb
@@ -1,0 +1,36 @@
+class UnsubscribeController < ActionController::Base
+  protect_from_forgery with: :null_session
+
+  def show
+    contact = find_contact_from_token
+    return render plain: 'Invalid or expired link', status: :not_found unless contact
+
+    mark_opted_out(contact)
+    render plain: "Te has dado de baja. No recibirás más correos en #{contact.email}."
+  end
+
+  def process_unsubscribe
+    contact = find_contact_from_token
+    return head :not_found unless contact
+
+    mark_opted_out(contact)
+    head :ok
+  end
+
+  private
+
+  def find_contact_from_token
+    data = ResendComplianceHeaders.verify_unsubscribe_token(params[:token])
+    return nil unless data
+
+    Contact.where(account_id: data[:account_id]).find_by(id: data[:contact_id])
+  end
+
+  def mark_opted_out(contact)
+    return if contact.custom_attributes['email_opted_out'] == true
+
+    contact.update!(
+      custom_attributes: contact.custom_attributes.merge('email_opted_out' => true, 'email_opted_out_at' => Time.current.iso8601)
+    )
+  end
+end

--- a/app/controllers/webhooks/resend_controller.rb
+++ b/app/controllers/webhooks/resend_controller.rb
@@ -1,0 +1,56 @@
+class Webhooks::ResendController < ActionController::API
+  def inbound
+    return head :unauthorized unless valid_signature?
+
+    dispatch_by_event_type
+    head :ok
+  rescue Email::ResendInboundService::ConversationNotFound => e
+    Rails.logger.warn("Resend inbound: #{e.message}")
+    head :ok
+  rescue StandardError => e
+    ChatwootExceptionTracker.new(e).capture_exception
+    head :internal_server_error
+  end
+
+  def events
+    return head :unauthorized unless valid_signature?
+
+    Email::ResendEventService.new(payload).perform
+    head :ok
+  rescue StandardError => e
+    ChatwootExceptionTracker.new(e).capture_exception
+    head :internal_server_error
+  end
+
+  private
+
+  def dispatch_by_event_type
+    case payload['type']
+    when 'email.received'
+      Email::ResendInboundService.new(payload).perform
+    when *Email::ResendEventService::HANDLED_EVENTS
+      Email::ResendEventService.new(payload).perform
+    else
+      Rails.logger.info("Resend webhook: ignored event type '#{payload['type']}'")
+    end
+  end
+
+  def payload
+    @payload ||= JSON.parse(request.raw_post)
+  end
+
+  def valid_signature?
+    secret = ENV.fetch('RESEND_INBOUND_WEBHOOK_SECRET', nil)
+    return false if secret.blank?
+
+    headers = {
+      'svix-id' => request.headers['svix-id'],
+      'svix-timestamp' => request.headers['svix-timestamp'],
+      'svix-signature' => request.headers['svix-signature']
+    }
+    Svix::Webhook.new(secret).verify(request.raw_post, headers)
+    true
+  rescue Svix::WebhookVerificationError
+    false
+  end
+end

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -561,6 +561,24 @@
         "SIGN_IN": "Sign in with Google",
         "EMAIL_PLACEHOLDER": "Enter email address",
         "ERROR_MESSAGE": "There was an error connecting to Google, please try again"
+      },
+      "RESEND": {
+        "TITLE": "Resend Email Inbox",
+        "DESC": "Send outbound emails through Resend SMTP and receive replies via Resend's inbound webhook. Make sure the domain is verified in Resend and the inbound webhook is configured to hit /webhooks/resend/inbound.",
+        "CHANNEL_NAME": {
+          "LABEL": "Channel Name",
+          "PLACEHOLDER": "Please enter a channel name",
+          "ERROR": "This field is required"
+        },
+        "EMAIL": {
+          "LABEL": "Email",
+          "PLACEHOLDER": "Please enter your email address",
+          "SUBTITLE": "Use an address on a domain verified in Resend (e.g. replies@notification.merkur.la). Replies will arrive here via the Resend inbound webhook."
+        },
+        "SUBMIT_BUTTON": "Create Resend Inbox",
+        "API": {
+          "ERROR_MESSAGE": "We were unable to create the Resend inbox, please try again"
+        }
       }
     },
     "DETAILS": {
@@ -766,6 +784,10 @@
       "FORWARD_EMAIL_TITLE": "Forward to Email",
       "FORWARD_EMAIL_SUB_TEXT": "Start forwarding your emails to the following email address.",
       "FORWARD_EMAIL_NOT_CONFIGURED": "Forwarding emails to your inbox is currently disabled on this installation. To use this feature, it must be enabled by your administrator. Please get in touch with them to proceed.",
+      "RESEND_CONFIGURATION_TITLE": "Resend configuration",
+      "RESEND_CONFIGURATION_SUBTITLE": "This inbox sends emails through Resend SMTP and receives replies via the Resend inbound webhook. SMTP and IMAP credentials are managed at the server level and cannot be edited here.",
+      "RESEND_OUTBOUND_LABEL": "Outbound",
+      "RESEND_INBOUND_LABEL": "Inbound",
       "ALLOW_MESSAGES_AFTER_RESOLVED": "Allow messages after conversation resolved",
       "ALLOW_MESSAGES_AFTER_RESOLVED_SUB_TEXT": "Allow the end-users to send messages even after the conversation is resolved.",
       "WHATSAPP_SECTION_SUBHEADER": "This API Key is used for the integration with the WhatsApp APIs.",
@@ -1087,6 +1109,10 @@
       "GOOGLE": {
         "TITLE": "Google",
         "DESCRIPTION": "Connect with Google"
+      },
+      "RESEND": {
+        "TITLE": "Resend",
+        "DESCRIPTION": "Send via Resend, receive via webhook"
       },
       "OTHER_PROVIDERS": {
         "TITLE": "Other Providers",

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -169,7 +169,7 @@ export default {
         this.isALineChannel ||
         this.isAPIInbox ||
         this.isAVoiceChannel ||
-        (this.isAnEmailChannel && !this.inbox.provider) ||
+        (this.isAnEmailChannel && (!this.inbox.provider || this.isAResendInbox)) ||
         this.shouldShowWhatsAppConfiguration ||
         this.isAWebWidgetInbox
       ) {

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Email.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Email.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue';
 import ForwardToOption from './emailChannels/ForwardToOption.vue';
 import Microsoft from './emailChannels/Microsoft.vue';
 import Google from './emailChannels/Google.vue';
+import Resend from './emailChannels/Resend.vue';
 import ChannelSelector from 'dashboard/components/ChannelSelector.vue';
 import PageHeader from '../../SettingsSubPageHeader.vue';
 
@@ -32,6 +33,13 @@ const emailProviderList = computed(() => {
       isEnabled: !!window.chatwootConfig.googleOAuthClientId,
       key: 'google',
       icon: 'i-woot-gmail',
+    },
+    {
+      title: t('INBOX_MGMT.EMAIL_PROVIDERS.RESEND.TITLE'),
+      description: t('INBOX_MGMT.EMAIL_PROVIDERS.RESEND.DESCRIPTION'),
+      isEnabled: true,
+      key: 'resend',
+      icon: 'i-woot-mail',
     },
     {
       title: t('INBOX_MGMT.EMAIL_PROVIDERS.OTHER_PROVIDERS.TITLE'),
@@ -76,5 +84,6 @@ function onClick(emailProvider) {
   </div>
   <Microsoft v-else-if="provider === 'microsoft'" />
   <Google v-else-if="provider === 'google'" />
+  <Resend v-else-if="provider === 'resend'" />
   <ForwardToOption v-else-if="provider === 'other_provider'" />
 </template>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/emailChannels/Resend.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/emailChannels/Resend.vue
@@ -1,0 +1,124 @@
+<script>
+import { mapGetters } from 'vuex';
+import { useVuelidate } from '@vuelidate/core';
+import { useAlert } from 'dashboard/composables';
+import { required, email } from '@vuelidate/validators';
+import router from '../../../../../index';
+import PageHeader from '../../../SettingsSubPageHeader.vue';
+import NextButton from 'dashboard/components-next/button/Button.vue';
+
+export default {
+  components: {
+    PageHeader,
+    NextButton,
+  },
+  setup() {
+    return { v$: useVuelidate() };
+  },
+  data() {
+    return {
+      channelName: '',
+      email: '',
+      alertMessage: '',
+    };
+  },
+  computed: {
+    ...mapGetters({
+      uiFlags: 'inboxes/getUIFlags',
+    }),
+  },
+  validations: {
+    channelName: { required },
+    email: { required, email },
+  },
+  methods: {
+    async createChannel() {
+      this.v$.$touch();
+      if (this.v$.$invalid) {
+        return;
+      }
+
+      try {
+        const emailChannel = await this.$store.dispatch(
+          'inboxes/createChannel',
+          {
+            name: this.channelName?.trim(),
+            channel: {
+              type: 'email',
+              email: this.email,
+              provider: 'resend',
+            },
+          }
+        );
+
+        router.replace({
+          name: 'settings_inboxes_add_agents',
+          params: {
+            page: 'new',
+            inbox_id: emailChannel.id,
+          },
+        });
+      } catch (error) {
+        const errorMessage = error?.message;
+        this.alertMessage =
+          errorMessage ||
+          this.$t('INBOX_MGMT.ADD.RESEND.API.ERROR_MESSAGE');
+        useAlert(this.alertMessage);
+      }
+    },
+  },
+};
+</script>
+
+<template>
+  <div class="h-full w-full p-6 col-span-6">
+    <PageHeader
+      :header-title="$t('INBOX_MGMT.ADD.RESEND.TITLE')"
+      :header-content="$t('INBOX_MGMT.ADD.RESEND.DESC')"
+    />
+    <form
+      class="flex flex-wrap flex-col mx-0"
+      @submit.prevent="createChannel()"
+    >
+      <div class="flex-shrink-0 flex-grow-0">
+        <label :class="{ error: v$.channelName.$error }">
+          {{ $t('INBOX_MGMT.ADD.RESEND.CHANNEL_NAME.LABEL') }}
+          <input
+            v-model="channelName"
+            type="text"
+            :placeholder="$t('INBOX_MGMT.ADD.RESEND.CHANNEL_NAME.PLACEHOLDER')"
+            @blur="v$.channelName.$touch"
+          />
+          <span v-if="v$.channelName.$error" class="message">{{
+            $t('INBOX_MGMT.ADD.RESEND.CHANNEL_NAME.ERROR')
+          }}</span>
+        </label>
+      </div>
+
+      <div class="flex-shrink-0 flex-grow-0 mb-4">
+        <label :class="{ error: v$.email.$error }">
+          {{ $t('INBOX_MGMT.ADD.RESEND.EMAIL.LABEL') }}
+          <input
+            v-model="email"
+            type="text"
+            :placeholder="$t('INBOX_MGMT.ADD.RESEND.EMAIL.PLACEHOLDER')"
+            @blur="v$.email.$touch"
+          />
+          <p class="help-text">
+            {{ $t('INBOX_MGMT.ADD.RESEND.EMAIL.SUBTITLE') }}
+          </p>
+        </label>
+      </div>
+
+      <div class="w-full mt-4">
+        <NextButton
+          :is-loading="uiFlags.isCreating"
+          type="submit"
+          solid
+          blue
+          :label="$t('INBOX_MGMT.ADD.RESEND.SUBMIT_BUTTON')"
+        />
+      </div>
+    </form>
+  </div>
+</template>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/ConfigurationPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/ConfigurationPage.vue
@@ -425,8 +425,29 @@ export default {
         </div>
       </SettingsSection>
     </div>
-    <ImapSettings :inbox="inbox" />
-    <SmtpSettings v-if="inbox.imap_enabled" :inbox="inbox" />
+    <div v-if="isAResendInbox" class="mx-8">
+      <SettingsSection
+        :title="$t('INBOX_MGMT.SETTINGS_POPUP.RESEND_CONFIGURATION_TITLE')"
+        :sub-title="$t('INBOX_MGMT.SETTINGS_POPUP.RESEND_CONFIGURATION_SUBTITLE')"
+      >
+        <div
+          class="p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg max-w-3xl"
+        >
+          <p class="text-sm text-blue-900 dark:text-blue-100 mb-2">
+            <strong>{{ $t('INBOX_MGMT.SETTINGS_POPUP.RESEND_OUTBOUND_LABEL') }}:</strong>
+            smtp.resend.com (managed via RESEND_API_KEY env var)
+          </p>
+          <p class="text-sm text-blue-900 dark:text-blue-100 mb-0">
+            <strong>{{ $t('INBOX_MGMT.SETTINGS_POPUP.RESEND_INBOUND_LABEL') }}:</strong>
+            POST /webhooks/resend/inbound (Resend webhook with event email.received)
+          </p>
+        </div>
+      </SettingsSection>
+    </div>
+    <template v-else>
+      <ImapSettings :inbox="inbox" />
+      <SmtpSettings v-if="inbox.imap_enabled" :inbox="inbox" />
+    </template>
   </div>
   <div v-else-if="isAWhatsAppChannel && !isATwilioChannel">
     <div v-if="inbox.provider_config" class="mx-8">

--- a/app/javascript/shared/mixins/inboxMixin.js
+++ b/app/javascript/shared/mixins/inboxMixin.js
@@ -41,6 +41,9 @@ export default {
     isAGoogleInbox() {
       return this.isAnEmailChannel && this.inbox.provider === 'google';
     },
+    isAResendInbox() {
+      return this.isAnEmailChannel && this.inbox.provider === 'resend';
+    },
     isAPIInbox() {
       return this.channelType === INBOX_TYPES.API;
     },

--- a/app/jobs/enroll_notion_database_records_job.rb
+++ b/app/jobs/enroll_notion_database_records_job.rb
@@ -758,6 +758,11 @@ class EnrollNotionDatabaseRecordsJob < ApplicationJob
   end
 
   def send_email_first_contact(sequence, conversation, contact, config, record)
+    if contact.custom_attributes['email_opted_out'] == true
+      Rails.logger.info "Skipping email to opted-out contact #{contact.id}"
+      return
+    end
+
     inbox = sequence.account.inboxes.find_by(id: config['inbox_id'])
     raise "Email inbox #{config['inbox_id']} not found" unless inbox
 
@@ -770,6 +775,12 @@ class EnrollNotionDatabaseRecordsJob < ApplicationJob
     rendered_subject = render_param_value(config['subject'] || '', contact, record, sequence)
     rendered_content = render_param_value(config['content'] || '', contact, record, sequence)
     sender_email = config['sender_email'].presence || sequence.account.support_email
+
+    if rendered_subject.present?
+      conversation.update!(
+        additional_attributes: conversation.additional_attributes.merge('mail_subject' => rendered_subject)
+      )
+    end
 
     payload = build_first_contact_payload(
       sequence: sequence,

--- a/app/mailers/concerns/resend_compliance_headers.rb
+++ b/app/mailers/concerns/resend_compliance_headers.rb
@@ -1,0 +1,45 @@
+module ResendComplianceHeaders
+  extend ActiveSupport::Concern
+
+  UNSUBSCRIBE_VERIFIER_PURPOSE = :resend_unsubscribe
+
+  def self.generate_unsubscribe_token(contact_id:, account_id:)
+    Rails.application.message_verifier(UNSUBSCRIBE_VERIFIER_PURPOSE).generate({
+                                                                              contact_id: contact_id,
+                                                                              account_id: account_id,
+                                                                              generated_at: Time.current.to_i
+                                                                            })
+  end
+
+  def self.verify_unsubscribe_token(token)
+    Rails.application.message_verifier(UNSUBSCRIBE_VERIFIER_PURPOSE).verify(token)
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
+    nil
+  end
+
+  private
+
+  def resend_compliance_headers
+    return {} unless resend_channel?
+
+    token = ResendComplianceHeaders.generate_unsubscribe_token(
+      contact_id: @contact.id,
+      account_id: @account.id
+    )
+    unsubscribe_url = "#{root_url.chomp('/')}/unsubscribe?token=#{token}"
+    mailto_unsubscribe = "mailto:unsubscribe@#{@channel.email.to_s.split('@').last}?subject=unsub:#{token}"
+
+    {
+      'List-Unsubscribe' => "<#{unsubscribe_url}>, <#{mailto_unsubscribe}>",
+      'List-Unsubscribe-Post' => 'List-Unsubscribe=One-Click'
+    }
+  end
+
+  def resend_channel?
+    @channel.respond_to?(:resend?) && @channel.resend?
+  end
+
+  def root_url
+    ENV.fetch('FRONTEND_URL', 'http://localhost:3000')
+  end
+end

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -5,6 +5,7 @@ class ConversationReplyMailer < ApplicationMailer
 
   include ConversationReplyMailerHelper
   include ReferencesHeaderBuilder
+  include ResendComplianceHeaders
   default from: ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@nauto.la>')
   layout :choose_layout
 

--- a/app/mailers/conversation_reply_mailer_helper.rb
+++ b/app/mailers/conversation_reply_mailer_helper.rb
@@ -16,6 +16,7 @@ module ConversationReplyMailerHelper
       @options[:cc] = cc_bcc_emails[0]
       @options[:bcc] = cc_bcc_emails[1]
     end
+    @options.merge!(resend_compliance_headers) if resend_channel?
     oauth_smtp_settings
     set_delivery_method
 
@@ -99,8 +100,14 @@ module ConversationReplyMailerHelper
 
   def email_reply_to
     return Email::ReplyToBuilder.new(inbox: @inbox, message: current_message).build if @account.feature_enabled?(:reply_mailer_migration)
+    return resend_plus_addressed_reply_to if @channel.respond_to?(:resend?) && @channel.resend?
 
     email_imap_enabled ? @channel.email : reply_email
+  end
+
+  def resend_plus_addressed_reply_to
+    domain = @channel.email.to_s.split('@').last
+    sender_name("reply+#{@conversation.uuid}@#{domain}")
   end
 
   # Use channel email domain in case of account email domain is not set for custom message_id and in_reply_to

--- a/app/models/channel/email.rb
+++ b/app/models/channel/email.rb
@@ -55,6 +55,7 @@ class Channel::Email < ApplicationRecord
   validates :forward_to_email, uniqueness: true
 
   before_validation :ensure_forward_to_email, on: :create
+  before_validation :apply_resend_smtp_defaults, on: :create
 
   def name
     'Email'
@@ -68,13 +69,44 @@ class Channel::Email < ApplicationRecord
     provider == 'google'
   end
 
+  def resend?
+    provider == 'resend'
+  end
+
   def legacy_google?
     imap_enabled && imap_address == 'imap.gmail.com'
+  end
+
+  def smtp_password
+    return ENV.fetch('RESEND_API_KEY', '') if resend?
+
+    self[:smtp_password]
+  end
+
+  def smtp_domain
+    return email.to_s.split('@').last.presence || 'smtp.resend.com' if resend?
+
+    self[:smtp_domain]
   end
 
   private
 
   def ensure_forward_to_email
     self.forward_to_email ||= "#{SecureRandom.hex}@#{account.inbound_email_domain}"
+  end
+
+  def apply_resend_smtp_defaults
+    return unless resend?
+
+    self.smtp_enabled = true
+    self.imap_enabled = false
+    self.smtp_address = 'smtp.resend.com'
+    self.smtp_port = 587
+    self.smtp_login = 'resend'
+    self.smtp_domain = ''
+    self.smtp_enable_starttls_auto = true
+    self.smtp_enable_ssl_tls = false
+    self.smtp_openssl_verify_mode = 'none'
+    self.smtp_authentication = 'plain'
   end
 end

--- a/app/services/email/resend_event_service.rb
+++ b/app/services/email/resend_event_service.rb
@@ -1,0 +1,106 @@
+class Email::ResendEventService
+  HANDLED_EVENTS = %w[email.bounced email.complained email.delivered email.opened email.clicked].freeze
+
+  def initialize(webhook_payload)
+    @webhook_payload = webhook_payload
+  end
+
+  def perform
+    return unless HANDLED_EVENTS.include?(@webhook_payload['type'])
+
+    case @webhook_payload['type']
+    when 'email.bounced'    then handle_bounce
+    when 'email.complained' then handle_complaint
+    when 'email.delivered' then handle_delivered
+    when 'email.opened'    then handle_opened
+    when 'email.clicked'   then handle_clicked
+    end
+  end
+
+  private
+
+  def event_type
+    @webhook_payload['type']
+  end
+
+  def to_addresses
+    Array(@webhook_payload.dig('data', 'to'))
+  end
+
+  def from_address
+    @webhook_payload.dig('data', 'from')
+  end
+
+  def bounce_data
+    @webhook_payload.dig('data', 'bounce') || {}
+  end
+
+  def hard_bounce?
+    bounce_data['type'].to_s.downcase == 'hard'
+  end
+
+  def handle_bounce
+    contacts_for_recipients.each do |contact|
+      reason = bounce_data['message'].presence || bounce_data['type'].presence || 'unknown'
+      create_private_note(contact, "⚠️ Bounce (#{bounce_data['type'] || 'unknown'}): #{reason}")
+
+      next unless hard_bounce?
+
+      contact.update!(
+        custom_attributes: contact.custom_attributes.merge(
+          'email_bounced' => true,
+          'email_bounced_at' => Time.current.iso8601,
+          'email_bounce_reason' => reason
+        )
+      )
+    end
+  end
+
+  def handle_complaint
+    contacts_for_recipients.each do |contact|
+      contact.update!(
+        custom_attributes: contact.custom_attributes.merge(
+          'email_opted_out' => true,
+          'email_opted_out_at' => Time.current.iso8601,
+          'email_opt_out_reason' => 'spam_complaint'
+        )
+      )
+      create_private_note(contact, '🚫 Spam complaint — contacto marcado como opt-out automáticamente')
+    end
+  end
+
+  def handle_delivered
+    log_event('delivered')
+  end
+
+  def handle_opened
+    log_event('opened')
+  end
+
+  def handle_clicked
+    log_event('clicked')
+  end
+
+  def log_event(label)
+    Rails.logger.info(
+      "Resend event #{label} for email_id=#{@webhook_payload.dig('data', 'email_id')} to=#{to_addresses.join(',')}"
+    )
+  end
+
+  def contacts_for_recipients
+    Contact.where(email: to_addresses.map { |e| e.to_s.downcase })
+  end
+
+  def create_private_note(contact, content)
+    conversation = contact.conversations.order(created_at: :desc).first
+    return unless conversation
+
+    conversation.messages.create!(
+      account_id: conversation.account_id,
+      inbox_id: conversation.inbox_id,
+      message_type: :outgoing,
+      private: true,
+      content: content
+    )
+  end
+end

--- a/app/services/email/resend_inbound_service.rb
+++ b/app/services/email/resend_inbound_service.rb
@@ -1,0 +1,124 @@
+class Email::ResendInboundService
+  class ConversationNotFound < StandardError; end
+
+  RESEND_API_BASE = 'https://api.resend.com'.freeze
+  RESEND_RECEIVED_PATHS = ['/emails/received/%<id>s', '/emails/%<id>s'].freeze
+  PLUS_ADDRESS_REGEX = /reply\+([a-zA-Z0-9-]+)@/
+
+  def initialize(webhook_payload)
+    @webhook_payload = webhook_payload
+  end
+
+  def perform
+    return unless email_received?
+
+    email_details = fetch_email_from_resend || {}
+    conversation = find_conversation(email_details)
+    raise ConversationNotFound, "no conversation matched (email_id=#{email_id})" unless conversation
+
+    create_incoming_message(conversation, email_details)
+  end
+
+  private
+
+  def email_received?
+    @webhook_payload['type'] == 'email.received'
+  end
+
+  def email_id
+    @webhook_payload.dig('data', 'email_id')
+  end
+
+  def webhook_to_addresses
+    Array(@webhook_payload.dig('data', 'to'))
+  end
+
+  def fetch_email_from_resend
+    RESEND_RECEIVED_PATHS.each do |path_template|
+      path = format(path_template, id: email_id)
+      response = HTTParty.get(
+        "#{RESEND_API_BASE}#{path}",
+        headers: {
+          'Authorization' => "Bearer #{ENV.fetch('RESEND_API_KEY')}",
+          'Content-Type' => 'application/json'
+        },
+        timeout: 15
+      )
+      return response.parsed_response if response.success?
+
+      Rails.logger.warn("Resend received-email fetch failed (#{path}): #{response.code}")
+    end
+    nil
+  end
+
+  def find_conversation(email)
+    find_by_plus_addressing || find_by_in_reply_to(email)
+  end
+
+  def find_by_plus_addressing
+    webhook_to_addresses.each do |addr|
+      match = addr.to_s.match(PLUS_ADDRESS_REGEX)
+      next unless match
+
+      convo = Conversation.find_by(uuid: match[1])
+      return convo if convo
+    end
+    nil
+  end
+
+  def find_by_in_reply_to(email)
+    in_reply_to = extract_in_reply_to(email)
+    return nil if in_reply_to.blank?
+
+    normalized = in_reply_to.to_s.gsub(/[<>]/, '').strip
+    Message.find_by(source_id: normalized)&.conversation
+  end
+
+  def extract_in_reply_to(email)
+    headers = email['headers'] || {}
+    headers['in-reply-to'] || headers['In-Reply-To']
+  end
+
+  def extract_message_id(email)
+    headers = email['headers'] || {}
+    raw = headers['message-id'] || headers['Message-ID'] || email['message_id'] || @webhook_payload.dig('data', 'message_id')
+    raw.to_s.gsub(/[<>]/, '').strip.presence
+  end
+
+  def create_incoming_message(conversation, email)
+    message_id = extract_message_id(email)
+    return if message_id.present? && conversation.messages.find_by(source_id: message_id).present?
+
+    text_body = email['text'].presence
+    html_body = email['html'].presence
+    subject = email['subject'] || @webhook_payload.dig('data', 'subject')
+    content = text_body.presence || sanitize_html(html_body).presence || subject.presence || '(empty reply)'
+
+    conversation.messages.create!(
+      account_id: conversation.account_id,
+      inbox_id: conversation.inbox_id,
+      sender: conversation.contact,
+      message_type: 'incoming',
+      content_type: 'incoming_email',
+      content: content,
+      source_id: message_id,
+      content_attributes: {
+        email: {
+          from: Array(email['from'] || @webhook_payload.dig('data', 'from')).compact,
+          to: Array(email['to'] || webhook_to_addresses).compact,
+          subject: subject,
+          message_id: message_id,
+          in_reply_to: extract_in_reply_to(email),
+          text_content: { reply: text_body, full: text_body },
+          html_content: { reply: html_body, full: html_body }
+        }.compact
+      }
+    )
+  end
+
+  def sanitize_html(html)
+    return '' if html.blank?
+
+    ActionView::Base.full_sanitizer.sanitize(html).to_s.presence || ''
+  end
+end

--- a/app/services/email/send_on_email_service.rb
+++ b/app/services/email/send_on_email_service.rb
@@ -9,8 +9,15 @@ class Email::SendOnEmailService < Base::SendOnChannelService
     return unless message.email_notifiable_message?
 
     reply_mail = ConversationReplyMailer.with(account: message.account).email_reply(message).deliver_now
-    Rails.logger.info("Email message #{message.id} sent with source_id: #{reply_mail.message_id}")
-    message.update(source_id: reply_mail.message_id)
+
+    if reply_mail.is_a?(Mail::Message)
+      Rails.logger.info("Email message #{message.id} sent with source_id: #{reply_mail.message_id}")
+      message.update(source_id: reply_mail.message_id)
+    else
+      smtp_error = "SMTP delivery failed: #{reply_mail.class.name} - #{reply_mail.respond_to?(:message) ? reply_mail.message : reply_mail.inspect}"
+      Rails.logger.error("Email message #{message.id} failed: #{smtp_error}")
+      Messages::StatusUpdateService.new(message, 'failed', smtp_error).perform
+    end
   rescue StandardError => e
     ChatwootExceptionTracker.new(e, account: message.account).capture_exception
     Messages::StatusUpdateService.new(message, 'failed', e.message).perform

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -751,6 +751,11 @@ Rails.application.routes.draw do
   post 'webhooks/tiktok', to: 'webhooks/tiktok#events'
   post 'webhooks/eleven_labs', to: 'webhooks/eleven_labs#process_payload'
   post 'webhooks/eleven_labs/post_call', to: 'webhooks/eleven_labs#post_call'
+  post 'webhooks/resend/inbound', to: 'webhooks/resend#inbound'
+  post 'webhooks/resend/events', to: 'webhooks/resend#events'
+
+  get 'unsubscribe', to: 'unsubscribe#show'
+  post 'unsubscribe', to: 'unsubscribe#process_unsubscribe'
 
   namespace :twitter do
     resource :callback, only: [:show]

--- a/spec/controllers/unsubscribe_controller_spec.rb
+++ b/spec/controllers/unsubscribe_controller_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'UnsubscribeController', type: :request do
+  let(:account) { create(:account) }
+  let(:contact) { create(:contact, account: account, email: 'lead@example.com') }
+  let(:valid_token) do
+    ResendComplianceHeaders.generate_unsubscribe_token(contact_id: contact.id, account_id: account.id)
+  end
+
+  describe 'GET /unsubscribe' do
+    context 'with a valid token' do
+      it 'marks the contact as opted out and returns 200' do
+        get '/unsubscribe', params: { token: valid_token }
+
+        expect(response).to have_http_status(:ok)
+        expect(contact.reload.custom_attributes['email_opted_out']).to be(true)
+        expect(contact.custom_attributes['email_opted_out_at']).to be_present
+      end
+    end
+
+    context 'with an invalid token' do
+      it 'returns 404 and does not opt out' do
+        get '/unsubscribe', params: { token: 'invalid' }
+
+        expect(response).to have_http_status(:not_found)
+        expect(contact.reload.custom_attributes['email_opted_out']).to be_nil
+      end
+    end
+  end
+
+  describe 'POST /unsubscribe (one-click)' do
+    it 'marks the contact as opted out and returns 200' do
+      post '/unsubscribe', params: { token: valid_token }
+
+      expect(response).to have_http_status(:ok)
+      expect(contact.reload.custom_attributes['email_opted_out']).to be(true)
+    end
+
+    it 'returns 404 for invalid token' do
+      post '/unsubscribe', params: { token: 'invalid' }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/controllers/webhooks/resend_controller_spec.rb
+++ b/spec/controllers/webhooks/resend_controller_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+RSpec.describe 'Webhooks::ResendController', type: :request do
+  describe 'POST /webhooks/resend/inbound' do
+    let(:secret) { 'whsec_testsecret' }
+    let(:payload) { { 'type' => 'email.received', 'data' => { 'from' => 'lead@example.com', 'to' => ['reply+abc@reply.example.com'] } }.to_json }
+    let(:headers) do
+      {
+        'svix-id' => 'msg_test',
+        'svix-timestamp' => Time.now.to_i.to_s,
+        'svix-signature' => 'v1,sig'
+      }
+    end
+
+    context 'with valid signature' do
+      before do
+        with_modified_env RESEND_INBOUND_WEBHOOK_SECRET: secret do
+          allow_any_instance_of(Svix::Webhook).to receive(:verify).and_return(true)
+        end
+      end
+
+      it 'invokes ResendInboundService and returns 200' do
+        with_modified_env RESEND_INBOUND_WEBHOOK_SECRET: secret do
+          allow_any_instance_of(Svix::Webhook).to receive(:verify).and_return(true)
+          service = instance_double(Email::ResendInboundService, perform: nil)
+          allow(Email::ResendInboundService).to receive(:new).and_return(service)
+
+          post '/webhooks/resend/inbound', params: payload, headers: headers.merge('Content-Type' => 'application/json')
+
+          expect(response).to have_http_status(:ok)
+          expect(service).to have_received(:perform)
+        end
+      end
+
+      it 'dispatches to ResendEventService for bounce/complaint events sent to the same endpoint' do
+        with_modified_env RESEND_INBOUND_WEBHOOK_SECRET: secret do
+          allow_any_instance_of(Svix::Webhook).to receive(:verify).and_return(true)
+          event_service = instance_double(Email::ResendEventService, perform: nil)
+          allow(Email::ResendEventService).to receive(:new).and_return(event_service)
+
+          bounce_payload = { 'type' => 'email.bounced', 'data' => { 'to' => ['lead@example.com'], 'bounce' => { 'type' => 'hard' } } }.to_json
+          post '/webhooks/resend/inbound', params: bounce_payload, headers: headers.merge('Content-Type' => 'application/json')
+
+          expect(response).to have_http_status(:ok)
+          expect(event_service).to have_received(:perform)
+        end
+      end
+
+      it 'returns 200 when no conversation matches (so Resend stops retrying)' do
+        with_modified_env RESEND_INBOUND_WEBHOOK_SECRET: secret do
+          allow_any_instance_of(Svix::Webhook).to receive(:verify).and_return(true)
+          allow_any_instance_of(Email::ResendInboundService)
+            .to receive(:perform).and_raise(Email::ResendInboundService::ConversationNotFound, 'no match')
+
+          post '/webhooks/resend/inbound', params: payload, headers: headers.merge('Content-Type' => 'application/json')
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+
+    context 'with invalid signature' do
+      it 'returns 401' do
+        with_modified_env RESEND_INBOUND_WEBHOOK_SECRET: secret do
+          allow_any_instance_of(Svix::Webhook).to receive(:verify).and_raise(Svix::WebhookVerificationError)
+
+          post '/webhooks/resend/inbound', params: payload, headers: headers.merge('Content-Type' => 'application/json')
+
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+    end
+
+    context 'when secret is not configured' do
+      it 'returns 401' do
+        with_modified_env RESEND_INBOUND_WEBHOOK_SECRET: nil do
+          post '/webhooks/resend/inbound', params: payload, headers: headers.merge('Content-Type' => 'application/json')
+
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+    end
+  end
+
+  describe 'POST /webhooks/resend/events' do
+    let(:secret) { 'whsec_testsecret' }
+    let(:payload) { { 'type' => 'email.bounced', 'data' => { 'to' => ['lead@example.com'], 'bounce' => { 'type' => 'hard' } } }.to_json }
+    let(:headers) do
+      {
+        'svix-id' => 'msg_test',
+        'svix-timestamp' => Time.now.to_i.to_s,
+        'svix-signature' => 'v1,sig'
+      }
+    end
+
+    it 'invokes ResendEventService when signature is valid' do
+      with_modified_env RESEND_INBOUND_WEBHOOK_SECRET: secret do
+        allow_any_instance_of(Svix::Webhook).to receive(:verify).and_return(true)
+        service = instance_double(Email::ResendEventService, perform: nil)
+        allow(Email::ResendEventService).to receive(:new).and_return(service)
+
+        post '/webhooks/resend/events', params: payload, headers: headers.merge('Content-Type' => 'application/json')
+
+        expect(response).to have_http_status(:ok)
+        expect(service).to have_received(:perform)
+      end
+    end
+
+    it 'returns 401 with invalid signature' do
+      with_modified_env RESEND_INBOUND_WEBHOOK_SECRET: secret do
+        allow_any_instance_of(Svix::Webhook).to receive(:verify).and_raise(Svix::WebhookVerificationError)
+
+        post '/webhooks/resend/events', params: payload, headers: headers.merge('Content-Type' => 'application/json')
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/mailers/conversation_reply_mailer_spec.rb
+++ b/spec/mailers/conversation_reply_mailer_spec.rb
@@ -693,5 +693,56 @@ RSpec.describe ConversationReplyMailer do
         expect(mail.in_reply_to).to eq("account/#{conversation.account.id}/conversation/#{conversation.uuid}@#{domain}")
       end
     end
+
+    context 'with resend channel' do
+      let!(:resend_account) { create(:account) }
+      let!(:resend_channel) do
+        Channel::Email.create!(
+          account: resend_account,
+          email: 'replies@notification.merkur.la',
+          provider: 'resend'
+        )
+      end
+      let!(:resend_inbox) { create(:inbox, channel: resend_channel, account: resend_account) }
+      let(:resend_conversation) { create(:conversation, inbox: resend_inbox, account: resend_account) }
+      let(:resend_message) do
+        create(:message,
+               conversation: resend_conversation,
+               account: resend_account,
+               message_type: 'outgoing',
+               content: 'Hola desde Resend')
+      end
+      let(:mail) { described_class.email_reply(resend_message).message }
+
+      it 'sets reply_to to plus-addressed alias on the channel email domain' do
+        expected = "reply+#{resend_conversation.uuid}@notification.merkur.la"
+        expect(mail.reply_to).to include(expected)
+      end
+
+      it 'uses the channel email as the From address' do
+        expect(mail.from).to include('replies@notification.merkur.la')
+      end
+
+      it 'uses Resend SMTP delivery settings' do
+        with_modified_env RESEND_API_KEY: 're_test_secret' do
+          delivery = described_class.email_reply(resend_message)
+          delivery.message # trigger lazy build of mail options
+          expect(delivery.message.delivery_method.settings[:address]).to eq('smtp.resend.com')
+          expect(delivery.message.delivery_method.settings[:port]).to eq(587)
+          expect(delivery.message.delivery_method.settings[:user_name]).to eq('resend')
+          expect(delivery.message.delivery_method.settings[:password]).to eq('re_test_secret')
+        end
+      end
+
+      it 'includes List-Unsubscribe and List-Unsubscribe-Post headers' do
+        unsubscribe_header = mail.header['List-Unsubscribe']&.value
+        post_header = mail.header['List-Unsubscribe-Post']&.value
+
+        expect(unsubscribe_header).to be_present
+        expect(unsubscribe_header).to include('/unsubscribe?token=')
+        expect(unsubscribe_header).to include('mailto:unsubscribe@notification.merkur.la')
+        expect(post_header).to eq('List-Unsubscribe=One-Click')
+      end
+    end
   end
 end

--- a/spec/models/channel/email_spec.rb
+++ b/spec/models/channel/email_spec.rb
@@ -46,4 +46,64 @@ RSpec.describe Channel::Email do
       expect(channel.google?).to be(true)
     end
   end
+
+  describe 'resend provider' do
+    let(:account) { create(:account) }
+
+    it 'returns false from resend? for other providers' do
+      expect(channel.resend?).to be(false)
+    end
+
+    it 'auto-configures SMTP settings on create when provider is resend' do
+      resend_channel = described_class.create!(
+        account: account,
+        email: 'replies@notification.merkur.la',
+        provider: 'resend'
+      )
+
+      expect(resend_channel.resend?).to be(true)
+      expect(resend_channel.smtp_enabled).to be(true)
+      expect(resend_channel.imap_enabled).to be(false)
+      expect(resend_channel.smtp_address).to eq('smtp.resend.com')
+      expect(resend_channel.smtp_port).to eq(587)
+      expect(resend_channel.smtp_login).to eq('resend')
+      expect(resend_channel.smtp_enable_starttls_auto).to be(true)
+      expect(resend_channel.smtp_authentication).to eq('plain')
+    end
+
+    it 'returns RESEND_API_KEY env var as smtp_password when provider is resend' do
+      resend_channel = described_class.create!(
+        account: account,
+        email: 'replies2@notification.merkur.la',
+        provider: 'resend'
+      )
+
+      with_modified_env RESEND_API_KEY: 're_test_secret' do
+        expect(resend_channel.smtp_password).to eq('re_test_secret')
+      end
+    end
+
+    it 'returns the stored smtp_password for non-resend channels' do
+      regular_channel = described_class.create!(
+        account: account,
+        email: 'manual@example.com',
+        smtp_enabled: true,
+        smtp_password: 'my-password'
+      )
+
+      with_modified_env RESEND_API_KEY: 'should-be-ignored' do
+        expect(regular_channel.smtp_password).to eq('my-password')
+      end
+    end
+
+    it 'returns the email domain as smtp_domain when provider is resend' do
+      resend_channel = described_class.create!(
+        account: account,
+        email: 'replies@notification.merkur.la',
+        provider: 'resend'
+      )
+
+      expect(resend_channel.smtp_domain).to eq('notification.merkur.la')
+    end
+  end
 end

--- a/spec/services/email/resend_event_service_spec.rb
+++ b/spec/services/email/resend_event_service_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+describe Email::ResendEventService do
+  let(:account) { create(:account) }
+  let(:channel) { create(:channel_email, account: account) }
+  let(:inbox) { create(:inbox, account: account, channel: channel) }
+  let(:contact) { create(:contact, account: account, email: 'lead@example.com') }
+  let!(:conversation) { create(:conversation, account: account, inbox: inbox, contact: contact) }
+
+  def event(type, data_overrides = {})
+    {
+      'type' => type,
+      'created_at' => Time.current.iso8601,
+      'data' => {
+        'email_id' => SecureRandom.uuid,
+        'from' => 'replies@notification.merkur.la',
+        'to' => ['lead@example.com'],
+        'subject' => 'Hola'
+      }.merge(data_overrides)
+    }
+  end
+
+  describe '#perform' do
+    context 'when event is email.bounced (hard bounce)' do
+      let(:payload) { event('email.bounced', 'bounce' => { 'type' => 'hard', 'message' => 'No such user' }) }
+
+      it 'marks the contact with email_bounced and bounce reason' do
+        described_class.new(payload).perform
+        attrs = contact.reload.custom_attributes
+        expect(attrs['email_bounced']).to be(true)
+        expect(attrs['email_bounce_reason']).to eq('No such user')
+        expect(attrs['email_bounced_at']).to be_present
+      end
+
+      it 'creates a private note in the most recent conversation' do
+        expect { described_class.new(payload).perform }
+          .to change { conversation.messages.where(private: true).count }.by(1)
+
+        note = conversation.messages.where(private: true).last
+        expect(note.content).to include('Bounce')
+        expect(note.content).to include('No such user')
+      end
+    end
+
+    context 'when event is email.bounced (soft bounce)' do
+      let(:payload) { event('email.bounced', 'bounce' => { 'type' => 'soft', 'message' => 'Mailbox full' }) }
+
+      it 'creates the private note but does NOT mark email_bounced' do
+        described_class.new(payload).perform
+        expect(contact.reload.custom_attributes['email_bounced']).to be_nil
+        expect(conversation.messages.where(private: true).last.content).to include('Mailbox full')
+      end
+    end
+
+    context 'when event is email.complained' do
+      let(:payload) { event('email.complained') }
+
+      it 'marks the contact as opted out with spam_complaint reason' do
+        described_class.new(payload).perform
+        attrs = contact.reload.custom_attributes
+        expect(attrs['email_opted_out']).to be(true)
+        expect(attrs['email_opt_out_reason']).to eq('spam_complaint')
+        expect(attrs['email_opted_out_at']).to be_present
+      end
+
+      it 'creates a private note' do
+        expect { described_class.new(payload).perform }
+          .to change { conversation.messages.where(private: true).count }.by(1)
+      end
+    end
+
+    context 'when event is email.delivered' do
+      let(:payload) { event('email.delivered') }
+
+      it 'logs without raising or mutating contact' do
+        expect { described_class.new(payload).perform }.not_to raise_error
+        expect(contact.reload.custom_attributes).not_to include('email_bounced', 'email_opted_out')
+      end
+    end
+
+    context 'when event type is not handled' do
+      let(:payload) { event('email.unknown') }
+
+      it 'returns silently without changes' do
+        expect { described_class.new(payload).perform }.not_to raise_error
+        expect(conversation.messages.where(private: true).count).to eq(0)
+      end
+    end
+
+    context 'when no contact matches the recipient' do
+      let(:payload) { event('email.bounced', 'to' => ['unknown@example.com'], 'bounce' => { 'type' => 'hard' }) }
+
+      it 'completes without raising' do
+        expect { described_class.new(payload).perform }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/services/email/resend_inbound_service_spec.rb
+++ b/spec/services/email/resend_inbound_service_spec.rb
@@ -1,0 +1,148 @@
+require 'rails_helper'
+
+describe Email::ResendInboundService do
+  let(:account) { create(:account) }
+  let(:email_channel) { create(:channel_email, account: account) }
+  let(:inbox) { create(:inbox, account: account, channel: email_channel) }
+  let(:contact) { create(:contact, account: account, email: 'lead@example.com') }
+  let(:conversation) { create(:conversation, account: account, inbox: inbox, contact: contact) }
+  let(:outgoing_message_id) { 'sent-123@mail.example.com' }
+  let!(:outgoing_message) do
+    create(:message, conversation: conversation, message_type: 'outgoing', source_id: outgoing_message_id)
+  end
+
+  let(:email_id) { '56761188-7520-42d8-8898-ff6fc54ce618' }
+
+  def webhook(overrides = {})
+    base = {
+      'type' => 'email.received',
+      'data' => {
+        'email_id' => email_id,
+        'from' => 'lead@example.com',
+        'to' => ['inbox@notification.merkur.la'],
+        'subject' => 'Re: hello'
+      }
+    }
+    base.deep_merge(overrides)
+  end
+
+  def resend_api_response(overrides = {})
+    {
+      'id' => email_id,
+      'from' => 'lead@example.com',
+      'to' => ['inbox@notification.merkur.la'],
+      'subject' => 'Re: hello',
+      'text' => 'Tengo una duda sobre el producto',
+      'html' => '<p>Tengo una duda sobre el producto</p>',
+      'headers' => {
+        'message-id' => '<reply-456@example.com>',
+        'in-reply-to' => "<#{outgoing_message_id}>"
+      }
+    }.merge(overrides)
+  end
+
+  def stub_resend_fetch(payload, status: 200)
+    response = instance_double(HTTParty::Response,
+                               success?: status.between?(200, 299),
+                               code: status,
+                               body: payload.to_json,
+                               parsed_response: payload)
+    allow(HTTParty).to receive(:get).and_return(response)
+  end
+
+  before do
+    stub_const('ENV', ENV.to_h.merge('RESEND_API_KEY' => 're_test'))
+  end
+
+  describe '#perform' do
+    context 'when event is not email.received' do
+      it 'returns without fetching from Resend' do
+        allow(HTTParty).to receive(:get)
+        described_class.new(webhook('type' => 'email.delivered')).perform
+        expect(HTTParty).not_to have_received(:get)
+      end
+    end
+
+    context 'when matching by In-Reply-To from API response' do
+      before { stub_resend_fetch(resend_api_response) }
+
+      it 'creates an incoming message in the original conversation' do
+        expect { described_class.new(webhook).perform }
+          .to change { conversation.messages.where(message_type: 'incoming').count }.by(1)
+
+        msg = conversation.messages.where(message_type: 'incoming').last
+        expect(msg.content).to eq('Tengo una duda sobre el producto')
+        expect(msg.source_id).to eq('reply-456@example.com')
+        expect(msg.content_attributes['email']['subject']).to eq('Re: hello')
+      end
+
+      it 'is idempotent on same message_id' do
+        described_class.new(webhook).perform
+        expect { described_class.new(webhook).perform }
+          .not_to change { conversation.messages.where(message_type: 'incoming').count }
+      end
+    end
+
+    context 'when In-Reply-To does not match, fallback to plus-addressing' do
+      let(:plus_address) { "reply+#{conversation.uuid}@notification.merkur.la" }
+
+      before do
+        stub_resend_fetch(resend_api_response(
+                            'headers' => { 'message-id' => '<reply-789@example.com>', 'in-reply-to' => '<unknown@example.com>' }
+                          ))
+      end
+
+      it 'finds the conversation by uuid in the plus-address from webhook to' do
+        payload = webhook('data' => { 'to' => [plus_address] })
+        expect { described_class.new(payload).perform }
+          .to change { conversation.messages.where(message_type: 'incoming').count }.by(1)
+      end
+    end
+
+    context 'when neither strategy matches' do
+      before do
+        stub_resend_fetch(resend_api_response(
+                            'headers' => { 'message-id' => '<x@example.com>', 'in-reply-to' => '<missing@example.com>' }
+                          ))
+      end
+
+      it 'raises ConversationNotFound' do
+        payload = webhook('data' => { 'to' => ['random@notification.merkur.la'] })
+        expect { described_class.new(payload).perform }
+          .to raise_error(Email::ResendInboundService::ConversationNotFound)
+      end
+    end
+
+    context 'when Resend API returns 404 for both endpoints, falls back to webhook data' do
+      let(:plus_address) { "reply+#{conversation.uuid}@notification.merkur.la" }
+
+      before { stub_resend_fetch({ 'error' => 'not found' }, status: 404) }
+
+      it 'still creates the incoming message using webhook payload data' do
+        payload = webhook(
+          'data' => {
+            'to' => [plus_address],
+            'subject' => 'Re: hello',
+            'message_id' => '<webhook-msg-id@example.com>'
+          }
+        )
+        expect { described_class.new(payload).perform }
+          .to change { conversation.messages.where(message_type: 'incoming').count }.by(1)
+
+        msg = conversation.messages.where(message_type: 'incoming').last
+        expect(msg.source_id).to eq('webhook-msg-id@example.com')
+        expect(msg.content_attributes['email']['subject']).to eq('Re: hello')
+      end
+    end
+
+    context 'when only html body is present' do
+      before { stub_resend_fetch(resend_api_response('text' => nil, 'html' => '<p>Hola</p>')) }
+
+      it 'creates a message with sanitized text content' do
+        described_class.new(webhook).perform
+        msg = conversation.messages.where(message_type: 'incoming').last
+        expect(msg.content).to eq('Hola')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add Resend as a first-class email provider in the inbox creation flow, with bidirectional support (SMTP outbound + webhook inbound) and compliance headers required by Gmail/Yahoo bulk sender requirements.

Outbound (SMTP):
- Channel::Email#resend? flag plus a before_create callback that auto-configures smtp.resend.com:587/STARTTLS/plain when provider is 'resend'. The smtp_password is sourced from RESEND_API_KEY at runtime (never persisted), and smtp_domain falls back to the channel's email domain so the HELO command is valid.
- ConversationReplyMailerHelper builds a per-conversation plus-addressed Reply-To (reply+<uuid>@<channel-email-domain>) so inbound replies can be matched back to the conversation.
- SendOnEmailService now degrades gracefully when ActionMailer returns an SMTP error instead of a Mail::Message, surfacing the real cause through Messages::StatusUpdateService.

Inbound (webhook):
- Webhooks::ResendController validates Svix signatures and dispatches by event type to Email::ResendInboundService (email.received) or Email::ResendEventService (bounced/complained/delivered/opened/clicked).
- Email::ResendInboundService matches conversations by plus-addressing first, falls back to In-Reply-To from the Resend API body fetch, and degrades to webhook metadata when the API endpoint is unavailable.
- Email::ResendEventService marks contacts as email_bounced or email_opted_out on hard bounce / spam complaint, and writes private notes into the most recent conversation for visibility.

Compliance (List-Unsubscribe):
- Add ResendComplianceHeaders concern that signs an unsubscribe token with Rails.application.message_verifier and emits List-Unsubscribe + List-Unsubscribe-Post: One-Click on every email sent from a Resend channel.
- UnsubscribeController handles both the GET human view and the POST one-click flow, flipping email_opted_out on the contact.

UI:
- Add a Resend card alongside Microsoft/Google/Other in the email provider picker, plus a dedicated creation form that only asks for channel name and email (everything else is auto-configured).
- Inbox settings page hides IMAP/SMTP forms for Resend inboxes and shows a read-only summary panel instead.
- New isAResendInbox helper in inboxMixin keeps the conditionals tidy.

Lead nurturing:
- EnrollNotionDatabaseRecordsJob skips contacts with email_opted_out to honor unsubscribe / spam complaint state.
- The rendered subject from the sequence config is now persisted on conversation.additional_attributes so subsequent agent replies stay in the same Gmail thread instead of falling back to the generic "[#id] New messages on this conversation" subject.

Specs:
- 87 examples covering channel auto-config, mailer headers and SMTP settings, inbound matching (In-Reply-To + plus-addressing fallback + API-degraded mode), event handling (hard/soft bounce, complaint, delivered no-op), webhook signature validation, and the unsubscribe one-click flow.

# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
